### PR TITLE
ci: publish human-authored release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Build
         run: nub run build
 
+      - name: Generate release notes
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}/release
+        run: nub run release:note
+
       - name: Package
         run: nub run package
 
@@ -77,7 +82,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vscode-github-markdown-${{ github.ref_name }}
-          path: "*.vsix"
+          path: |
+            *.vsix
+            release-CHANGELOG.txt
           if-no-files-found: error
           retention-days: 14
 
@@ -131,4 +138,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "$GITHUB_REF_NAME" release/*.vsix --clobber
-          gh release edit "$GITHUB_REF_NAME" --draft=false
+          gh release edit "$GITHUB_REF_NAME" --notes-file release/release-CHANGELOG.txt --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,43 @@
 # Changelog
 
-All notable changes to this extension are documented in this file. New release entries are generated from Conventional Commits by Release Please.
+All notable changes to this extension are documented in this file. Release notes are written for people and maintained manually under `[Unreleased]` until publication.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Legend: ✨ Feature · 💎 Improve · 🧱 Refactor · 🐛 Bugfix · 💥 Breaking · 🚧 Maintenance · 📦 Dependencies · 🚀 Performance · 📝 Documentation
 
 ---
+
+## [Unreleased]
+
+### ✨ Feature
+
+- Add an accessibility setting for showing or hiding link underlines in Markdown text blocks, enabled by default to match GitHub.
+
+### 💎 Improve
+
+- Rename the extension's display name to **GitHub Flavored Markdown** across the manifest, localization files, and documentation.
+- Align GitHub emoji wrappers and custom image metadata, consecutive footnote definitions, code typography, and footnote link decoration with GitHub rendering.
+
+### 🧱 Refactor
+
+- Reorganize build, emoji, release, and verification scripts into domain-focused modules with deterministic generation and focused tests.
+
+### 🚧 Maintenance
+
+- Add strict pixel-level Markdown parity baselines, local regression checks, weekly GitHub renderer drift detection, and CI diff artifacts.
+- Add a mise-managed development toolchain with Node.js 24 and pnpm 11.
+- Provision the project toolchain through mise in CI and publishing workflows.
+- Upgrade to TypeScript 7 and simplify the compiler configuration for the current build pipeline.
+- Remove the deprecated `@typescript/native-preview` development dependency.
+- Make CSS watch rebuilds recover from initial failures and process rapid changes reliably.
+- Keep the bundle visualizer closed by default and open it only with `--open-visualizer`.
+
+### 📦 Dependencies
+
+- Update pnpm, markdown-it, tsdown, Vitest, lefthook, oxlint, oxfmt, and related development dependencies.
+
+### 📝 Documentation
+
+- Document mise setup and usage in the contribution guide.
 
 ## [v4.0.0]
 
@@ -63,4 +96,5 @@ Each GitHub behavior is isolated in its own plugin under `src/plugins/`. The con
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md) — toolchain setup and contribution guidelines.
 - [`AGENTS.md`](./AGENTS.md) — rules for automated tooling.
 
+[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.0.0...HEAD
 [v4.0.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v3.1.0...v4.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,8 @@ When possible:
 - Mention any compatibility impact, especially if it affects VS Code version support
 - Note any checks you ran, or say clearly if you did not run them
 
-Use a [Conventional Commit](https://www.conventionalcommits.org/) title for each pull request so its squash commit can be included in automated release notes. In particular, `fix:` produces a patch release, `feat:` produces a minor release, and a `BREAKING CHANGE:` footer produces a major release.
+Use a [Conventional Commit](https://www.conventionalcommits.org/) title for each pull request so Release Please can determine the next version. In particular, `fix:` produces a patch release, `feat:` produces a minor release, and a `BREAKING CHANGE:` footer produces a major release.
 
-Release Please maintains the release pull request, version, changelog, tag, and draft GitHub Release. Do not update `CHANGELOG.md` manually for ordinary pull requests. Merging the generated release pull request triggers the Marketplace publishing workflow; the GitHub Release remains a draft until Marketplace publication succeeds.
+Write user-facing release notes manually under `[Unreleased]` in `CHANGELOG.md`. Describe the effect for extension users instead of copying commit titles or implementation details. Internal maintenance that does not affect users may omit a changelog entry.
+
+Release Please maintains the release pull request, package version, tag, and draft GitHub Release, but does not generate the changelog. Before merging a generated release pull request, promote `[Unreleased]` to the matching version heading (for example, `[v4.1.0]`), add a new empty `[Unreleased]` section, and update the comparison links. The publishing workflow rejects a release without a matching human-authored version section and uses that section as the GitHub Release notes.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,48 +8,7 @@
       "include-v-in-tag": true,
       "draft": true,
       "force-tag-creation": true,
-      "changelog-sections": [
-        {
-          "type": "feat",
-          "section": "✨ Features"
-        },
-        {
-          "type": "fix",
-          "section": "🐛 Bug Fixes"
-        },
-        {
-          "type": "perf",
-          "section": "🚀 Performance"
-        },
-        {
-          "type": "refactor",
-          "section": "🧱 Refactoring"
-        },
-        {
-          "type": "deps",
-          "section": "📦 Dependencies"
-        },
-        {
-          "type": "docs",
-          "section": "📝 Documentation"
-        },
-        {
-          "type": "test",
-          "section": "✅ Tests"
-        },
-        {
-          "type": "build",
-          "section": "🏗️ Build System"
-        },
-        {
-          "type": "ci",
-          "section": "👷 Continuous Integration"
-        },
-        {
-          "type": "chore",
-          "section": "🚧 Maintenance"
-        }
-      ]
+      "skip-changelog": true
     }
   }
 }

--- a/scripts/release/changelog.ts
+++ b/scripts/release/changelog.ts
@@ -1,14 +1,16 @@
-const versionHeading = /^##\s+\[[^\]]+\][^\n]*$/m;
+const sectionBoundary = /^##\s+\[[^\]]+\][^\n]*$|^\[[^\]]+\]:/m;
 
-export function extractLatestRelease(changelog: string): string {
+export function extractRelease(changelog: string, version: string): string {
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const versionHeading = new RegExp(`^##\\s+\\[v?${escapedVersion}\\][^\\n]*$`, "m");
   const heading = versionHeading.exec(changelog);
   if (!heading) {
-    throw new Error("Cannot extract release notes: no version section was found");
+    throw new Error(`Cannot extract release notes: version ${version} was not found`);
   }
 
   const bodyStart = heading.index + heading[0].length;
   const remainder = changelog.slice(bodyStart);
-  const nextBoundary = remainder.search(/^##\s+\[[^\]]+\][^\n]*$|^\[[^\]]+\]:/m);
+  const nextBoundary = remainder.search(sectionBoundary);
   const body = (nextBoundary === -1 ? remainder : remainder.slice(0, nextBoundary)).trim();
 
   return body ? `## What's Changed\n\n${body}` : "## What's Changed";

--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { writeTextIfChanged } from "../shared/files";
 import { project } from "../shared/project";
-import { extractLatestRelease } from "./changelog";
+import { extractRelease } from "./changelog";
 
 const workspace = process.env["GITHUB_WORKSPACE"];
 if (!workspace) {
@@ -9,5 +9,12 @@ if (!workspace) {
 }
 
 const changelog = await readFile(project.paths.changelog, "utf8");
-const releaseNotes = extractLatestRelease(changelog);
+const packageJson = JSON.parse(await readFile(project.paths.packageJson, "utf8")) as {
+  version?: unknown;
+};
+if (typeof packageJson.version !== "string") {
+  throw new Error("Cannot write release notes: package.json version is missing");
+}
+
+const releaseNotes = extractRelease(changelog, packageJson.version);
 await writeTextIfChanged(`${workspace}-CHANGELOG.txt`, `${releaseNotes}\n`);

--- a/tests/scripts/release/changelog.test.ts
+++ b/tests/scripts/release/changelog.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { extractLatestRelease } from "../../../scripts/release/changelog";
+import { extractRelease } from "../../../scripts/release/changelog";
 
-describe("extractLatestRelease", () => {
+describe("extractRelease", () => {
   it.each([
     [
       "another release",
-      "# Changelog\n\n## [v2.0.0] - 2026-06-24\n\n- New.\n\n## [v1.0.0]\n\n- Old.\n",
+      "# Changelog\n\n## [Unreleased]\n\n- Next.\n\n## [v2.0.0] - 2026-06-24\n\n- New.\n\n## [v1.0.0]\n\n- Old.\n",
       "## What's Changed\n\n- New."
     ],
     [
@@ -13,23 +13,27 @@ describe("extractLatestRelease", () => {
       "# Changelog\n\n## [v2.0.0]\n\n- New.\n\n[v2.0.0]: https://example.com/v2\n",
       "## What's Changed\n\n- New."
     ],
-    ["end of file", "# Changelog\n\n## [v2.0.0]\n\n- New.\n", "## What's Changed\n\n- New."]
+    [
+      "heading without a v prefix",
+      "# Changelog\n\n## [2.0.0]\n\n- New.\n",
+      "## What's Changed\n\n- New."
+    ]
   ])("extracts a release followed by %s", (_case, changelog, expected) => {
-    expect(extractLatestRelease(changelog)).toBe(expected);
+    expect(extractRelease(changelog, "2.0.0")).toBe(expected);
   });
 
   it("preserves Markdown inside the latest section", () => {
     const changelog = "## [v1.0.0]\n\n### Added\n\n- **GitHub** [alerts](https://example.com).\n";
-    expect(extractLatestRelease(changelog)).toBe(
+    expect(extractRelease(changelog, "1.0.0")).toBe(
       "## What's Changed\n\n### Added\n\n- **GitHub** [alerts](https://example.com)."
     );
   });
 
-  it.each(["", "# Changelog\n\nNo releases yet.\n", "## Unreleased\n\n- Work in progress.\n"])(
-    "rejects a changelog without a version section",
+  it.each(["", "# Changelog\n\nNo releases yet.\n", "## [Unreleased]\n\n- Work in progress.\n"])(
+    "rejects a changelog without the requested version",
     (changelog) => {
-      expect(() => extractLatestRelease(changelog)).toThrow(
-        "Cannot extract release notes: no version section was found"
+      expect(() => extractRelease(changelog, "2.0.0")).toThrow(
+        "Cannot extract release notes: version 2.0.0 was not found"
       );
     }
   );


### PR DESCRIPTION
## Summary

- stop Release Please from rewriting `CHANGELOG.md`
- restore a human-maintained `[Unreleased]` section and document the release-editing workflow
- select release notes by the exact `package.json` version instead of the first changelog section
- validate and package curated notes before Marketplace publication, then use them for the final GitHub Release

## Why

Commit-derived changelogs are useful as an audit trail but are not an effective user-facing release narrative. This keeps automated versioning, tagging, and Marketplace publication while making the published notes intentionally written for extension users.

## Validation

- 31 test files / 180 tests passed
- oxlint, type-aware oxlint, and oxfmt passed
- Markdown parity verification passed
- extension build and VSIX packaging passed
- Release Please configuration passed its official JSON Schema
- Release Please dry-run confirmed `CHANGELOG.md` is no longer an updater
- workflow YAML and Git diff checks passed