### PR TITLE
docs: adopt a user-facing changelog standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ This project is a VS Code extension that makes local Markdown preview match GitH
 - [`src/extension.ts`](./src/extension.ts): extension entrypoint
 - [`README.md`](./README.md): default English documentation
 - [`README.zh-CN.md`](./README.zh-CN.md): Simplified Chinese documentation
+- [`CHANGELOG.md`](./CHANGELOG.md): canonical user-facing release record
+- [`docs/CHANGELOG_STYLE_GUIDE.md`](./docs/CHANGELOG_STYLE_GUIDE.md): required changelog content and writing standard
 - [`tsconfig.json`](./tsconfig.json): strict TypeScript config
 - [`lefthook.yml`](./lefthook.yml): pre-commit checks
 
@@ -53,6 +55,9 @@ This project is a VS Code extension that makes local Markdown preview match GitH
 - `README.zh-CN.md` is the Simplified Chinese counterpart.
 - When updating shared project-facing documentation, keep both files aligned unless the change is intentionally language-specific.
 - Do not claim a feature is implemented unless it exists in the current codebase.
+- Follow [`docs/CHANGELOG_STYLE_GUIDE.md`](./docs/CHANGELOG_STYLE_GUIDE.md) for every new `CHANGELOG.md` entry.
+- For every change, evaluate the guide's admission rules. Add eligible changes under `[Unreleased]` and intentionally omit ineligible internal work.
+- Record only user-observable or user-actionable outcomes in the changelog. Omit implementation, testing, tooling, CI, and dependency details unless they materially affect extension users.
 
 ## Versioning Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This file records notable changes that people can observe or act on when using the extension. New entries follow the project-owned [`User-Facing Changelog Standard`](./docs/CHANGELOG_STYLE_GUIDE.md) and remain under `[Unreleased]` until publication. Entries released before the standard took effect remain in their original form.
+This file records notable changes that people can observe or act on when using the extension. Every entry follows the project-owned [`User-Facing Changelog Standard`](./docs/CHANGELOG_STYLE_GUIDE.md), and upcoming changes remain under `[Unreleased]` until publication.
 
 ---
 
@@ -14,101 +14,56 @@ This file records notable changes that people can observe or act on when using t
 
 - You can now follow a complete migration path from `lzm0x219.vscode-markdown-github`. [Install the new extension from the Marketplace](https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown) or run `code --install-extension lzm0x219.vscode-github-markdown`, verify the new preview, and then uninstall the previous extension to avoid overlapping preview customizations.
 
-## [v4.1.0]
+## [v4.1.0] - 2026-07-12
 
-This release focuses on making the local Markdown preview both closer to GitHub and easier to keep that way over time.
+This release makes links easier to identify and improves the visual consistency of footnotes, emoji, and code with GitHub. Existing settings continue to work, and no migration is required.
 
-- **Closer GitHub rendering:** Adds configurable GitHub-style link underlines, adopts the **GitHub Flavored Markdown** name, and closes gaps in emoji metadata, consecutive footnotes, code typography, and footnote link decoration.
-- **Measurable parity:** Introduces deterministic verification scripts, strict pixel-level regression baselines, and scheduled detection of upstream GitHub renderer changes.
-- **Modern tooling:** Moves development and CI to a mise-managed Node.js 24 and pnpm 11 toolchain, with refreshed TypeScript, linting, formatting, testing, build, and packaging dependencies.
+### Accessibility
 
-### ✨ Feature
+- Links in regular Markdown text are now underlined by default to match GitHub. Set `githubMarkdown.accessibility.linkUnderlines` to `false` to hide them.
+- Footnote references and return links remain without underlines so they keep GitHub's distinct footnote appearance in either link setting.
 
-- Add an accessibility setting for showing or hiding link underlines in Markdown text blocks, enabled by default to match GitHub.
+### Markdown preview
 
-### 💎 Improve
+- Consecutive footnote definitions now remain separate notes with the expected numbering instead of being combined into one definition.
+- GitHub custom image emoji now align vertically with surrounding text and show their shortcode on hover. The `:warning:` shortcode now follows GitHub's emoji markup for more consistent rendering.
+- Code blocks now use the typography supplied by the selected GitHub theme instead of always using the VS Code editor font.
 
-- Rename the extension's display name to **GitHub Flavored Markdown** across the manifest, localization files, and documentation.
-- Align GitHub emoji wrappers and custom image metadata, consecutive footnote definitions, code typography, and footnote link decoration with GitHub rendering.
+### Extension identity
 
-### 🧱 Refactor
+- The extension is now displayed as **GitHub Flavored Markdown** in VS Code and the Marketplace, making its purpose easier to recognize.
 
-- Reorganize build, emoji, release, and verification scripts into domain-focused modules with deterministic generation and focused tests.
+## [v4.0.0] - 2026-06-24
 
-### 🚧 Maintenance
+v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdown-github`; it rebuilds the GitHub-style preview around VS Code's built-in Markdown preview. Existing v3 users must install it separately, and anyone who wants to preserve their v3 theme behavior must migrate those settings manually.
 
-- Add strict pixel-level Markdown parity baselines, local regression checks, weekly GitHub renderer drift detection, and CI diff artifacts.
-- Add a mise-managed development toolchain with Node.js 24 and pnpm 11.
-- Provision the project toolchain through mise in CI and publishing workflows.
-- Upgrade to TypeScript 7 and simplify the compiler configuration for the current build pipeline.
-- Remove the deprecated `@typescript/native-preview` development dependency.
-- Make CSS watch rebuilds recover from initial failures and process rapid changes reliably.
-- Keep the bundle visualizer closed by default and open it only with `--open-visualizer`.
+### Action required
 
-### 📦 Dependencies
+- **Breaking:** If you use `lzm0x219.vscode-markdown-github`, [install `lzm0x219.vscode-github-markdown` separately](https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown); VS Code does not update the previous extension ID in place. Confirm the v4 preview works, then disable or uninstall the previous extension so both extensions do not customize the preview together.
+- **Breaking:** If you want to preserve your v3 theme behavior, migrate `vscode-markdown-github.theme.mode`, `vscode-markdown-github.theme.light`, and `vscode-markdown-github.theme.dark` because v4 does not read them. Map `light` to `githubMarkdown.theme.mode = single` and copy `vscode-markdown-github.theme.light` to `githubMarkdown.theme.single`; map `dark` to `githubMarkdown.theme.mode = single` and copy `vscode-markdown-github.theme.dark` to `githubMarkdown.theme.single`; map `auto` to `githubMarkdown.theme.mode = system`, copy `vscode-markdown-github.theme.light` to `githubMarkdown.theme.light`, and copy `vscode-markdown-github.theme.dark` to `githubMarkdown.theme.dark`.
+- **Breaking:** If you rely on Mermaid diagrams, [install `markdown-mermaid` separately](https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid). v4 no longer includes a Mermaid renderer; it only synchronizes the companion extension's theme.
 
-- Update pnpm, markdown-it, tsdown, Vitest, lefthook, oxlint, oxfmt, and related development dependencies.
+### Markdown preview
 
-### 📝 Documentation
+- Task lists render as GitHub-style disabled checkboxes inside VS Code's built-in Markdown preview.
+- GitHub alerts written with `[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, or `[!CAUTION]` render with matching icons and colors.
+- Emoji shortcodes such as `:rocket:`, `:+1:`, and `:tada:` render as Unicode or GitHub custom image emoji.
+- Footnote references receive automatic numbering, return links, and a dedicated footnotes section.
+- Project-root paths in HTML `<img>` tags are rewritten for the VS Code webview so local images can load in the preview.
 
-- Document mise setup and usage in the contribution guide.
+### Themes and appearance
 
-## [v4.0.0]
+- Theme selection now uses **Single** mode for one fixed theme or **System** mode for separate light and dark choices across nine GitHub themes.
+- The Command Palette provides separate controls for theme mode, the fixed theme, and the light and dark system themes.
 
-v4 is a ground-up rewrite. The extension has been renamed from `vscode-markdown-github` to **vscode-github-markdown** and rebuilt as a chain of focused `markdown-it` plugins that plug into VS Code's built-in Markdown preview pipeline. The theme system now offers 9 GitHub themes with preview light/dark switching, and the entire build toolchain has been modernized.
+### Mermaid
 
-### 💥 Breaking
+- When `markdown-mermaid` is installed, `githubMarkdown.mermaid.syncTheme` is enabled by default. On activation or after a GitHub Markdown setting changes, v4 updates one of the companion extension's `markdown-mermaid.lightModeTheme` or `markdown-mermaid.darkModeTheme` settings to Mermaid's `default` or `dark` theme.
 
-- **Extension renamed** — `vscode-markdown-github` → `vscode-github-markdown`. This is a new extension; install it separately.
-- **Architecture** — a `markdown-it` plugin chain registered via `markdown.markdownItPlugins` replaces the previous standalone renderer.
-- **VS Code** — minimum version raised to `^1.74.0`.
-- **Node.js** — 22+ for development. Runtime stays web-extension compatible.
-- **Build & lint** — Nub + tsdown replaces webpack/esbuild. oxlint + oxfmt + lefthook replaces eslint.
-- **Theme config** — `mode` (single / system) with per-mode theme selection replaces the old three-option model.
+### Installation and compatibility
 
-### ✨ Feature
-
-**GitHub-Flavored Markdown rendering.** Five `markdown-it` plugins correct VS Code's built-in output to match GitHub:
-
-- **Task Lists** — `- [x]` and `- [ ]` render as GitHub-style disabled checkboxes.
-- **Alerts** — `[!NOTE]` / `[!TIP]` / `[!IMPORTANT]` / `[!WARNING]` / `[!CAUTION]` with proper icons and colors.
-- **Emoji** — `:rocket:` / `:+1:` / `:tada:` and thousands more, plus GitHub custom emoji.
-- **Footnotes** — `[^1]` with automatic numbering, backrefs, and a dedicated section.
-- **HTML image paths** — absolute paths in HTML `<img>` tags (`/path/to/img`) rewritten to relative (`./path/to/img`) for correct webview loading.
-
-**Themes.** 9 built-in themes generated from `generate-github-markdown-css`: Light, Dark, Dark dimmed, Light/Dark high contrast, Light/Dark Protanopia & Deuteranopia, Light/Dark Tritanopia. Two modes — _Single_ (one fixed theme) or _System_ (follows the preview light/dark color scheme). Switch themes anytime via Quick Pick commands (`changeThemeMode`, `changeSingleTheme`, `changeLightTheme`, `changeDarkTheme`).
-
-**Mermaid.** When `githubMarkdown.mermaid.syncTheme` is enabled, the extension maps the active GitHub Markdown theme to the `markdown-mermaid` light/dark theme settings. It does not bundle a Mermaid renderer.
-
-**i18n.** All user-facing strings externalized via `@vscode/l10n`.
-
-**Verification.** `nub scripts/verify-github-markdown.ts` validates the full rendering pipeline against comprehensive GFM test fixtures.
-
-### 🧱 Refactor
-
-Four-layer architecture documented in [`ARCHITECTURE.md`](./ARCHITECTURE.md):
-
-```txt
-Manifest & Contribution → Extension Host → Markdown Transform → Preview Presentation
-```
-
-Each GitHub behavior is isolated in its own plugin under `src/plugins/`. The configuration surface is deliberately minimal: theme selection and Mermaid sync. Preview styles and scripts are injected through standard VS Code contribution points — no custom rendering pipeline.
-
-### 📦 Dependencies
-
-| Area           | Before                               | After                             |
-| -------------- | ------------------------------------ | --------------------------------- |
-| CSS generation | `@primer/css` + `@primer/primitives` | `generate-github-markdown-css`    |
-| Build          | webpack / esbuild                    | `nub` + `tsdown` + `lightningcss` |
-| Lint & format  | eslint                               | `oxlint` + `oxfmt` + `lefthook`   |
-| Dev tooling    | —                                    | `@vscode/vsce` + `publint`        |
-
-### 📝 Documentation
-
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — design, layers, constraints, and non-goals.
-- [`README.md`](./README.md) / [`README.zh-CN.md`](./README.zh-CN.md) — features, theme table, and Mermaid sync behavior.
-- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — toolchain setup and contribution guidelines.
-- [`AGENTS.md`](./AGENTS.md) — rules for automated tooling.
+- v4 supports VS Code 1.74 or later and continues to enhance the built-in Markdown preview instead of opening a separate preview editor.
+- Commands and settings are available in English and Simplified Chinese according to the VS Code display language.
 
 [v4.1.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.0.0...v4.1.0
 [v4.0.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v3.1.0...v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,18 @@
 # Changelog
 
-All notable changes to this extension are documented in this file. Release notes are written for people and maintained manually under `[Unreleased]` until publication.
-
-Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Legend: ✨ Feature · 💎 Improve · 🧱 Refactor · 🐛 Bugfix · 💥 Breaking · 🚧 Maintenance · 📦 Dependencies · 🚀 Performance · 📝 Documentation
+This file records notable changes that people can observe or act on when using the extension. New entries follow the project-owned [`User-Facing Changelog Standard`](./docs/CHANGELOG_STYLE_GUIDE.md) and remain under `[Unreleased]` until publication. Entries released before the standard took effect remain in their original form.
 
 ---
 
 ## [Unreleased]
 
-### 🐛 Bugfix
+### Mermaid
 
-- Keep Mermaid's light and dark appearance aligned with the selected preview themes, and restore the user's previous Mermaid settings when synchronization is disabled.
+- When `markdown-mermaid` is installed and `githubMarkdown.mermaid.syncTheme` is enabled, Mermaid diagrams now stay aligned with the selected preview themes. Turning off synchronization restores your previous Mermaid light and dark theme settings.
 
-### 📝 Documentation
+### Installation and migration
 
-- Add direct installation and migration guidance plus verified rendering comparisons.
+- You can now follow a complete migration path from `lzm0x219.vscode-markdown-github`. [Install the new extension from the Marketplace](https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown) or run `code --install-extension lzm0x219.vscode-github-markdown`, verify the new preview, and then uninstall the previous extension to avoid overlapping preview customizations.
 
 ## [v4.1.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,10 @@ When possible:
 
 Use a [Conventional Commit](https://www.conventionalcommits.org/) title for each pull request so Release Please can determine the next version. In particular, `fix:` produces a patch release, `feat:` produces a minor release, and a `BREAKING CHANGE:` footer produces a major release.
 
-Write user-facing release notes manually under `[Unreleased]` in `CHANGELOG.md`. Describe the effect for extension users instead of copying commit titles or implementation details. Internal maintenance that does not affect users may omit a changelog entry.
+## Changelog and Releases
 
-Release Please maintains the release pull request, package version, tag, and draft GitHub Release, but does not generate the changelog. Before merging a generated release pull request, promote `[Unreleased]` to the matching version heading (for example, `[v4.1.0]`), add a new empty `[Unreleased]` section, and update the comparison links. The publishing workflow rejects a release without a matching human-authored version section and uses that section as the GitHub Release notes.
+`CHANGELOG.md` is the canonical user-facing release record. Every new entry must follow the [`User-Facing Changelog Standard`](./docs/CHANGELOG_STYLE_GUIDE.md).
+
+Add a change under `[Unreleased]` only when someone using the extension can observe it or must act on it. Describe the resulting behavior, affected context, and any required action. Do not record implementation, testing, tooling, CI, or dependency maintenance unless it materially changes the user experience.
+
+Release Please maintains the release pull request, package version, tag, and draft GitHub Release, but does not generate the changelog. Before merging a generated release pull request, curate `[Unreleased]`, promote it to a dated matching version heading (for example, `[v4.2.0] - 2026-07-15`), add a new empty `[Unreleased]` section, and update the comparison links. The publishing workflow rejects a release without a matching human-authored version section and uses that section as the GitHub Release notes.

--- a/docs/CHANGELOG_STYLE_GUIDE.md
+++ b/docs/CHANGELOG_STYLE_GUIDE.md
@@ -1,10 +1,10 @@
 # User-Facing Changelog Standard
 
 - Status: Active
-- Version: 1.0
+- Version: 1.1
 - Effective: 2026-07-15
 
-This is the project-owned standard for writing `CHANGELOG.md`. It applies to `[Unreleased]` and every release published after its effective date. Older release entries remain historical records and do not need to be rewritten solely to match this standard.
+This is the project-owned standard for writing `CHANGELOG.md`. It applies to `[Unreleased]` and every published release entry in the file. Historical entries may be curated for clarity, but they must describe only the behavior of the tagged release and must not acquire capabilities added later.
 
 The standard is informed by [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html), but its content model is deliberately organized around the experience of people using the extension rather than development activity or commit types.
 

--- a/docs/CHANGELOG_STYLE_GUIDE.md
+++ b/docs/CHANGELOG_STYLE_GUIDE.md
@@ -1,0 +1,191 @@
+# User-Facing Changelog Standard
+
+- Status: Active
+- Version: 1.0
+- Effective: 2026-07-15
+
+This is the project-owned standard for writing `CHANGELOG.md`. It applies to `[Unreleased]` and every release published after its effective date. Older release entries remain historical records and do not need to be rewritten solely to match this standard.
+
+The standard is informed by [Keep a Changelog](https://keepachangelog.com/en/2.0.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html), but its content model is deliberately organized around the experience of people using the extension rather than development activity or commit types.
+
+The words **must**, **should**, and **may** describe requirements, recommendations, and optional practices in this document.
+
+## Purpose and Audience
+
+The changelog helps someone decide whether to install or update the extension and understand what the update means for their Markdown preview.
+
+Every entry must make the first two answers clear. It must answer the third whenever an action is required:
+
+1. What will I notice after updating?
+2. When or where will I notice it?
+3. Do I need to change anything?
+
+`CHANGELOG.md` is the canonical release record. GitHub Release notes are generated from the matching version section, so each release section must also make sense when read outside the repository.
+
+## Admission Rules
+
+A change belongs in the changelog when it materially affects at least one of these user outcomes:
+
+- Rendered Markdown or its visual parity with GitHub
+- Preview interaction, appearance, accessibility, or reliability
+- Commands, settings, defaults, or other extension behavior
+- Installation, migration, supported VS Code versions, or compatibility with another extension
+- User-observable performance, resource usage, security, or privacy
+- Documentation that enables a significant installation, migration, configuration, or troubleshooting task
+
+The changelog must not include a change that is only about:
+
+- Refactoring or code organization
+- Tests, fixtures, coverage, or verification infrastructure
+- CI, publishing, packaging, or development tooling
+- Dependency or lockfile maintenance
+- Formatting, comments, or routine documentation cleanup
+
+If internal work produces a user-observable result, document only that result. Do not document the implementation work that produced it.
+
+When uncertain, use this test:
+
+> If the implementation details and pull request disappeared, could someone using the extension still observe or act on this change?
+
+If the answer is no, omit it.
+
+## Release Structure
+
+Use these headings:
+
+```markdown
+## [Unreleased]
+
+### Markdown preview
+
+- ...
+
+## [v4.2.0] - 2026-07-15
+
+One or two sentences describing the release's main user outcome.
+
+### Action required
+
+- ...
+
+### Markdown preview
+
+- ...
+
+### Themes and appearance
+
+- ...
+
+### Known limitations
+
+- ...
+```
+
+The following rules apply:
+
+- Published release headings must use `## [vVERSION] - YYYY-MM-DD`. When preparing that release, `VERSION` must equal the value in `package.json`, and `vVERSION` must equal the Git tag. Historical headings retain the version they were released with.
+- `[Unreleased]` has no date and does not require a summary.
+- A published release must begin with a one- or two-sentence summary of its main user outcome.
+- `Action required`, when present, must be the first section after the summary.
+- `Known limitations`, when present, must be the last section.
+- `Known limitations` may include only limitations introduced by or especially relevant to that release. Do not repeat an unchanged backlog across releases.
+- Include only sections that contain entries. Do not add empty sections.
+- Prefer stable product-domain headings such as `Markdown preview`, `Themes and appearance`, `Mermaid`, `Accessibility`, and `Installation and compatibility`.
+- A release may introduce another plain-language product-domain heading when it is clearer for users.
+- Prefer the relevant product domain for fixes. Use `Fixes` only for a short set of unrelated corrections that would otherwise create several one-item sections.
+- Section headings must be plain English and must not depend on emoji or internal change-type labels such as `Refactor`, `Maintenance`, or `Dependencies`.
+- Order sections and entries by user impact, with the most important first.
+- The summary must synthesize the release outcome rather than repeat detailed entries verbatim.
+
+## Writing an Entry
+
+Each bullet must:
+
+- Lead with the behavior or outcome someone can observe
+- Name the affected feature, setting, content type, or condition
+- State any required action directly
+- Stand on its own without relying on its heading for essential meaning
+- Use present tense, active voice, plain English, and established product terminology
+- Keep to one idea and normally no more than two sentences
+- End with a period
+
+Use `you` when it makes an available action or required migration clearer. Avoid `we`, contributor-oriented narration, commit-message prefixes, filenames, source symbols, and tool names unless someone using the extension must know them.
+
+Use exact command, extension, and setting identifiers in backticks. Describe verified behavior precisely; do not use claims such as “identical to GitHub” when the change only improves parity in specific cases.
+
+The canonical changelog is written in English. Translated release communication may be published separately, but it must preserve the same user impact and required actions.
+
+### Before and After
+
+| Avoid                                          | Write instead                                                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Refactor Mermaid synchronization state.        | Turning off Mermaid theme synchronization now restores your previous Mermaid light and dark theme settings. |
+| Update `markdown-it` and regenerate snapshots. | Omit it, unless the update changes behavior someone can observe.                                            |
+| Fix footnote bug.                              | Consecutive footnote definitions now keep the same numbering and spacing as GitHub.                         |
+| Add link underline configuration.              | You can now show GitHub-style underlines on links to make them easier to identify.                          |
+| Add visual regression tests for alerts.        | Omit it.                                                                                                    |
+
+## Actions, Compatibility, and Security
+
+An entry under `Action required` must state:
+
+1. Who is affected and under what condition
+2. What behavior or interface changed
+3. The exact action needed to continue using the feature
+
+### Breaking Changes
+
+A change is breaking when an existing supported setting, command, workflow, compatibility target, or documented behavior no longer works without user action.
+
+Every breaking change must:
+
+- Ship in a SemVer-major release
+- Appear under `Action required` before all product-domain sections
+- Begin with `**Breaking:**`
+- Identify who is affected, what stops working, and the exact migration action
+- Link to a migration guide when the required procedure is too long for one or two sentences
+
+The release summary must warn that the update requires action. For example:
+
+```markdown
+### Action required
+
+- **Breaking:** If your settings use `<old-setting>`, replace it with `<new-setting>` before updating. The old setting is no longer read.
+```
+
+For deprecations, state the replacement and the planned removal version only when that plan is committed. For compatibility changes, name the affected VS Code or companion-extension versions.
+
+For security changes, explain the user impact and required update without publishing details that are still embargoed. Link to the public advisory when one exists.
+
+## Links and Release Notes
+
+- Put optional issue or pull request links at the end of an entry; the user-facing statement must remain understandable without opening them.
+- Use inline links inside a release section. The release-note extractor does not include reference definitions stored at the bottom of `CHANGELOG.md`.
+- Do not use a ticket number, commit hash, or pull request title as the entry text.
+- Keep detailed migration procedures in a dedicated guide and link to it from `Action required`.
+
+## Workflow
+
+1. Add an eligible change under `[Unreleased]` in the same pull request that changes user-observable behavior.
+2. Before release, review `[Unreleased]` as a whole: remove internal noise, merge related entries, use consistent terminology, and order by impact.
+3. Promote the content into a dated `## [vVERSION] - YYYY-MM-DD` section, add its summary, and create a new empty `[Unreleased]` section.
+4. Update the comparison links at the bottom of `CHANGELOG.md`.
+5. Generate the release notes and confirm the extracted section is complete and understandable on its own.
+
+Automation may draft or validate entries, but a person must curate the final wording and decide what is notable.
+
+## Review Checklist
+
+Before merging or publishing, confirm:
+
+- Every entry describes something observable or actionable for someone using the extension.
+- The summary explains the release outcome without duplicating the entries.
+- Required actions and compatibility changes are prominent and exact.
+- Every breaking change is prominent, actionable, and reflected in the major version.
+- Internal implementation and maintenance details are absent.
+- Product names, commands, settings, and supported versions match the current codebase.
+- Related entries are merged and ordered by user impact.
+- Every link works when the version section is rendered as GitHub Release notes.
+- The release-note extraction test and relevant formatting checks pass.
+
+Changes to this standard should include a rationale and an example showing how the change improves communication for extension users.

--- a/tests/scripts/release/changelog.test.ts
+++ b/tests/scripts/release/changelog.test.ts
@@ -22,10 +22,11 @@ describe("extractRelease", () => {
     expect(extractRelease(changelog, "2.0.0")).toBe(expected);
   });
 
-  it("preserves Markdown inside the latest section", () => {
-    const changelog = "## [v1.0.0]\n\n### Added\n\n- **GitHub** [alerts](https://example.com).\n";
+  it("preserves the user-facing release structure", () => {
+    const changelog =
+      "## [v1.0.0] - 2026-07-15\n\nPreview behavior is now closer to GitHub, and this update requires a settings change.\n\n### Action required\n\n- **Breaking:** If your settings use `old.setting`, replace it with `new.setting`; the old setting is no longer read.\n\n### Markdown preview\n\n- **GitHub** [alerts](https://example.com) now render consistently.\n";
     expect(extractRelease(changelog, "1.0.0")).toBe(
-      "## What's Changed\n\n### Added\n\n- **GitHub** [alerts](https://example.com)."
+      "## What's Changed\n\nPreview behavior is now closer to GitHub, and this update requires a settings change.\n\n### Action required\n\n- **Breaking:** If your settings use `old.setting`, replace it with `new.setting`; the old setting is no longer read.\n\n### Markdown preview\n\n- **GitHub** [alerts](https://example.com) now render consistently."
     );
   });
 


### PR DESCRIPTION
## Summary

- Define a project-owned standard for user-facing release notes.
- Rewrite the v4.0.0 and v4.1.0 entries around user impact, migration steps, and tagged behavior.
- Wire the standard into contributor guidance and keep release-note extraction compatible with dated headings.

## User impact

Release notes now prioritize observable changes, required actions, and exact settings while omitting internal engineering noise.

## Validation

- nub run test — 180 tests passed
- nubx oxfmt --check on the changed documentation
- release-note extraction for v4.0.0 and v4.1.0
- release:note generation