### PR TITLE
ci: persist generated release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,8 +71,6 @@ jobs:
         run: nub run build
 
       - name: Generate release notes
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}/release
         run: nub run release:note
 
       - name: Package

--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { writeTextIfChanged } from "../shared/files";
 import { project } from "../shared/project";
 import { extractRelease } from "./changelog";
@@ -17,4 +18,4 @@ if (typeof packageJson.version !== "string") {
 }
 
 const releaseNotes = extractRelease(changelog, packageJson.version);
-await writeTextIfChanged(`${workspace}-CHANGELOG.txt`, `${releaseNotes}\n`);
+await writeTextIfChanged(join(workspace, "release-CHANGELOG.txt"), `${releaseNotes}\n`);

--- a/tests/scripts/release/index.test.ts
+++ b/tests/scripts/release/index.test.ts
@@ -1,0 +1,26 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("release notes output", () => {
+  it("writes the generated notes inside GITHUB_WORKSPACE", async () => {
+    const workspace = await mkdtemp(join(tmpdir(), "vscode-github-markdown-release-"));
+    temporaryDirectories.push(workspace);
+    vi.stubEnv("GITHUB_WORKSPACE", workspace);
+    vi.resetModules();
+
+    await import("../../../scripts/release/index");
+
+    await expect(readFile(join(workspace, "release-CHANGELOG.txt"), "utf8")).resolves.toContain(
+      "## What's Changed"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Write generated release notes inside the actual GitHub Actions workspace.
- Remove the ineffective override of the reserved `GITHUB_WORKSPACE` variable.
- Add a regression test for the artifact output location.

## Root cause

The release script wrote to `${GITHUB_WORKSPACE}-CHANGELOG.txt`, while the publish workflow uploaded `release-CHANGELOG.txt`. GitHub Actions does not support changing the reserved workspace variable as an output-path mechanism, so the artifact contained only the VSIX and the GitHub Release finalize job failed.

## Impact

Future tag publications will include both the VSIX and human-authored release notes in the shared artifact, allowing the finalize job to publish the GitHub Release automatically.

## Validation

- 181 tests passed
- oxlint and type-aware lint passed
- oxfmt check passed
- direct `release:note` output-path verification passed