### PR TITLE
docs: improve README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://vsmarketplacebadges.dev/version-short/lzm0x219.vscode-github-markdown.svg" /></a>
-  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
-  <img alt="Requires VS Code 1.74 or later" src="https://img.shields.io/badge/VS%20Code-1.74%2B-007ACC?logo=visualstudiocode&logoColor=white" />
-  <a href="./LICENSE"><img alt="MIT license" src="https://img.shields.io/github/license/lzm0x219/vscode-github-markdown" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?icon=visualstudiocode&iconColor=white" /></a>
+  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI status" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main" /></a>
+  <img alt="Requires VS Code 1.74 or later" src="https://badges.ws/badge/VS%20Code-1.74%2B-007ACC?icon=visualstudiocode&iconColor=white" />
+  <a href="./LICENSE"><img alt="MIT license" src="https://badges.ws/badge/License-MIT-3979E1" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <img alt="VS Code ^1.74.0" src="https://badges.ws/badge/VS%20Code-%5E1.74.0-007ACC?logo=visualstudiocode&logoColor=white" />
-  <img alt="Nub" src="https://badges.ws/badge/Nub-toolkit-f9f1e1" />
-  <img alt="Oxc" src="https://badges.ws/badge/Oxc-Linter-32f3e9?logo=oxc&logoColor=white" />
-  <img alt="License MIT" src="https://badges.ws/badge/License-MIT-3979E1" />
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://vsmarketplacebadges.dev/version-short/lzm0x219.vscode-github-markdown.svg" /></a>
+  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
+  <img alt="Requires VS Code 1.74 or later" src="https://img.shields.io/badge/VS%20Code-1.74%2B-007ACC?logo=visualstudiocode&logoColor=white" />
+  <a href="./LICENSE"><img alt="MIT license" src="https://img.shields.io/github/license/lzm0x219/vscode-github-markdown" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?icon=visualstudiocode&iconColor=white" /></a>
-  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI status" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main" /></a>
-  <img alt="Requires VS Code 1.74 or later" src="https://badges.ws/badge/VS%20Code-1.74%2B-007ACC?icon=visualstudiocode&iconColor=white" />
-  <a href="./LICENSE"><img alt="MIT license" src="https://badges.ws/badge/License-MIT-3979E1" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?label=Marketplace&labelColor=24292F&color=007ACC" /></a>
+  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI status" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main&label=CI&labelColor=24292F" /></a>
+  <img alt="Requires VS Code 1.74 or later" src="https://badges.ws/badge/VS%20Code-%E2%89%A5%201.74-007ACC?labelColor=24292F" />
+  <a href="./LICENSE"><img alt="MIT license" src="https://badges.ws/badge/License-MIT-8250DF?labelColor=24292F" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?label=Marketplace&labelColor=24292F&color=007ACC" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace version" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?label=Marketplace&labelColor=24292F" /></a>
+  <a href="#desktop-and-web"><img alt="Desktop and web extension hosts" src="https://badges.ws/badge/Hosts-Desktop%20%2B%20Web-BC4C00?labelColor=24292F" /></a>
   <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI status" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main&label=CI&labelColor=24292F" /></a>
-  <img alt="Requires VS Code 1.74 or later" src="https://badges.ws/badge/VS%20Code-%E2%89%A5%201.74-007ACC?labelColor=24292F" />
   <a href="./LICENSE"><img alt="MIT license" src="https://badges.ws/badge/License-MIT-8250DF?labelColor=24292F" /></a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?icon=visualstudiocode&iconColor=white" /></a>
-  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI 状态" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main" /></a>
-  <img alt="需要 VS Code 1.74 或更高版本" src="https://badges.ws/badge/VS%20Code-1.74%2B-007ACC?icon=visualstudiocode&iconColor=white" />
-  <a href="./LICENSE"><img alt="MIT 许可证" src="https://badges.ws/badge/License-MIT-3979E1" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?label=Marketplace&labelColor=24292F&color=007ACC" /></a>
+  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI 状态" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main&label=CI&labelColor=24292F" /></a>
+  <img alt="需要 VS Code 1.74 或更高版本" src="https://badges.ws/badge/VS%20Code-%E2%89%A5%201.74-007ACC?labelColor=24292F" />
+  <a href="./LICENSE"><img alt="MIT 许可证" src="https://badges.ws/badge/License-MIT-8250DF?labelColor=24292F" /></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <img alt="VS Code ^1.74.0" src="https://badges.ws/badge/VS%20Code-%5E1.74.0-007ACC?logo=visualstudiocode&logoColor=white" />
-  <img alt="Nub" src="https://badges.ws/badge/Nub-toolkit-f9f1e1" />
-  <img alt="Oxc" src="https://badges.ws/badge/Oxc-Linter-32f3e9?logo=oxc&logoColor=white" />
-  <img alt="License MIT" src="https://badges.ws/badge/License-MIT-3979E1" />
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://vsmarketplacebadges.dev/version-short/lzm0x219.vscode-github-markdown.svg" /></a>
+  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
+  <img alt="需要 VS Code 1.74 或更高版本" src="https://img.shields.io/badge/VS%20Code-1.74%2B-007ACC?logo=visualstudiocode&logoColor=white" />
+  <a href="./LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/github/license/lzm0x219/vscode-github-markdown" /></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?label=Marketplace&labelColor=24292F&color=007ACC" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?label=Marketplace&labelColor=24292F" /></a>
+  <a href="#桌面端与-web"><img alt="支持桌面端与 Web 扩展宿主" src="https://badges.ws/badge/Hosts-Desktop%20%2B%20Web-BC4C00?labelColor=24292F" /></a>
   <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI 状态" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main&label=CI&labelColor=24292F" /></a>
-  <img alt="需要 VS Code 1.74 或更高版本" src="https://badges.ws/badge/VS%20Code-%E2%89%A5%201.74-007ACC?labelColor=24292F" />
   <a href="./LICENSE"><img alt="MIT 许可证" src="https://badges.ws/badge/License-MIT-8250DF?labelColor=24292F" /></a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,10 +9,10 @@
 </p>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://vsmarketplacebadges.dev/version-short/lzm0x219.vscode-github-markdown.svg" /></a>
-  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml/badge.svg?branch=main" /></a>
-  <img alt="需要 VS Code 1.74 或更高版本" src="https://img.shields.io/badge/VS%20Code-1.74%2B-007ACC?logo=visualstudiocode&logoColor=white" />
-  <a href="./LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/github/license/lzm0x219/vscode-github-markdown" /></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=lzm0x219.vscode-github-markdown"><img alt="VS Marketplace 版本" src="https://badges.ws/vscode/v/lzm0x219.vscode-github-markdown?icon=visualstudiocode&iconColor=white" /></a>
+  <a href="https://github.com/lzm0x219/vscode-github-markdown/actions/workflows/ci.yml"><img alt="CI 状态" src="https://badges.ws/github/actions/workflow/status/lzm0x219/vscode-github-markdown/ci.yml?branch=main" /></a>
+  <img alt="需要 VS Code 1.74 或更高版本" src="https://badges.ws/badge/VS%20Code-1.74%2B-007ACC?icon=visualstudiocode&iconColor=white" />
+  <a href="./LICENSE"><img alt="MIT 许可证" src="https://badges.ws/badge/License-MIT-3979E1" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- replace maintainer-tool badges with user-facing Marketplace, host support, CI, and license signals
- standardize badge rendering on `badges.ws` with concise labels and distinct semantic colors
- keep the English and Simplified Chinese READMEs aligned

## Validation

- `nubx oxfmt --check README.md README.zh-CN.md`
- verified all four badge endpoints return HTTP 200 SVGs with expected labels and colors
- `nub run package -- --out /tmp/vscode-github-markdown-badge-hosts.vsix`
- two-axis standards/spec review completed with no findings