### PR TITLE
fix(ci): install Chromium for web host tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Cache Chromium
+        if: matrix.kind == 'web'
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Chromium
+        if: matrix.kind == 'web'
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Desktop Extension Host smoke test
         if: matrix.kind == 'desktop'
         env:


### PR DESCRIPTION
## What changed

- Cache and install Playwright Chromium before Web Extension Host smoke and preview tests.

## Why

Playwright 1.62.0 requires a new Chromium headless shell. The host job did not download it, so the web smoke test could not launch a browser.

## Validation

- Parsed `.github/workflows/ci.yml` as YAML.
- Ran `git diff --check`.
- Confirmed the same install command succeeded in the failing workflow run's `check` job.