### PR TITLE
ci: remove Node.js 20 action warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - uses: nubjs/setup-nub@v0
+      - name: Install nub
+        run: npm install --global @nubjs/nub
 
       - run: pnpm install --frozen-lockfile
 
@@ -78,7 +79,8 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - uses: nubjs/setup-nub@v0
+      - name: Install nub
+        run: npm install --global @nubjs/nub
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,8 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - uses: nubjs/setup-nub@v0
+      - name: Install nub
+        run: npm install --global @nubjs/nub
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -23,7 +23,8 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - uses: nubjs/setup-nub@v0
+      - name: Install nub
+        run: npm install --global @nubjs/nub
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- replace four `nubjs/setup-nub@v0` workflow steps with the equivalent Nub CLI installation command
- keep Node.js and pnpm provisioning on the existing version-pinned `jdx/mise-action@v4` path
- retain the repository's direct `actions/cache@v6` usage

## Root cause

`nubjs/setup-nub@v0` is a composite action whose `Cache nub store` step references `actions/cache@v4`. GitHub Actions downloads that nested action and reports its Node.js 20 runtime as deprecated even though this repository's direct cache steps already use `actions/cache@v6`.

## Impact

CI, release, and upstream drift workflows should no longer load the Node.js 20 cache action. Project runtime versions remain pinned by `mise.toml`.

## Validation

- YAML parsing for all three changed workflows
- `nubx oxfmt --check .github/workflows/ci.yml .github/workflows/publish.yml .github/workflows/upstream-drift.yml`
- `git diff --check`
- confirmed no remaining `nubjs/setup-nub@` or `actions/cache@v4` references under `.github/workflows`