### PR TITLE
ci: enforce release gates and recovery drill

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,40 @@
+{
+  "name": "main release gates",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          {
+            "context": "check"
+          },
+          {
+            "context": "Host smoke (desktop-minimum)"
+          },
+          {
+            "context": "Host smoke (desktop-stable)"
+          },
+          {
+            "context": "Host smoke (web-stable)"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/drift-drill.yml
+++ b/.github/workflows/drift-drill.yml
@@ -1,0 +1,38 @@
+name: Simulated upstream drift drill
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drill:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+
+      - name: Install nub
+        run: npm install --global @nubjs/nub
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run simulated upstream drift recovery drill
+        run: pnpm run drill:drift
+
+      - name: Emit the simulated drift alert
+        run: echo "::warning title=Simulated upstream drift::Detected and classified within the 30-hour SLO; see the drill evidence artifact."
+
+      - name: Add drill evidence to the workflow summary
+        run: cat artifacts/drift-drill/report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload drill evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: simulated-drift-drill-${{ github.run_id }}
+          path: artifacts/drift-drill
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,31 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      override_reason:
+        description: Why the fresh upstream parity gate must be overridden
+        required: false
+        type: string
+      override_owner:
+        description: Person accountable for the override
+        required: false
+        type: string
+      override_report_url:
+        description: HTTPS URL to the reviewed parity or incident report
+        required: false
+        type: string
 
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  quality-gate:
+    uses: ./.github/workflows/ci.yml
+
   verify:
+    needs: quality-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -52,6 +70,38 @@ jobs:
 
       - name: Install Chromium
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Prepare release gate audit
+        id: release_gate
+        env:
+          RELEASE_GATE_OVERRIDE_REASON: ${{ inputs.override_reason }}
+          RELEASE_GATE_OVERRIDE_OWNER: ${{ inputs.override_owner }}
+          RELEASE_GATE_OVERRIDE_REPORT_URL: ${{ inputs.override_report_url }}
+        run: nub scripts/release/gate-index.ts prepare
+
+      - name: Verify fresh upstream three-way parity
+        id: upstream_parity
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm run verify:parity:report
+
+      - name: Enforce fresh upstream parity
+        if: always()
+        env:
+          RELEASE_GATE_PARITY_OUTCOME: ${{ steps.upstream_parity.outcome }}
+        run: nub scripts/release/gate-index.ts enforce
+
+      - name: Upload release gate evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-gate-${{ github.ref_name }}-${{ github.run_id }}
+          path: |
+            artifacts/release-gate
+            artifacts/parity
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Lint
         run: nubx oxlint .

--- a/docs/RELEASE_RECOVERY.md
+++ b/docs/RELEASE_RECOVERY.md
@@ -1,0 +1,117 @@
+# Release gates and recovery
+
+This runbook covers the enforced `main` and release gates, upstream provenance review, audited
+overrides, recovery, and rollback.
+
+## Main protection
+
+The repository ruleset is versioned at `.github/rulesets/main.json`. It requires the core CI check
+and the desktop minimum, desktop stable, and Web stable host checks, rejects branch deletion, and
+rejects non-fast-forward updates. It has no bypass actors.
+
+Inspect and apply the ruleset:
+
+```bash
+gh api repos/lzm0x219/vscode-github-markdown/rulesets
+gh api --method POST repos/lzm0x219/vscode-github-markdown/rulesets \
+  --input .github/rulesets/main.json
+```
+
+Update an existing ruleset by replacing `POST` with `PUT` and appending its numeric ID to the URL.
+Review the live response after every change; do not assume the checked-in file was applied.
+
+## Provenance and three-way comparison
+
+Before refreshing any baseline, download the latest probe artifact, inspect its captured CSS
+provenance, and run the independent three-way comparison:
+
+```bash
+gh run download RUN_ID \
+  --name upstream-drift-RUN_ID \
+  --dir artifacts/upstream-drift-RUN_ID
+jq '.cssSnapshot | {capturedAt, extractor, fixtureCommit, assets}' \
+  artifacts/upstream-drift-RUN_ID/drift/report.json
+pnpm run verify:parity:report
+jq '{conclusion, stages, metadata}' artifacts/parity/three-way-report.json
+```
+
+Interpret the three comparisons independently:
+
+- baseline GitHub versus current GitHub identifies upstream drift;
+- current extension versus current GitHub identifies user impact;
+- current extension versus the committed baseline identifies local regressions.
+
+Do not refresh when fetch, extraction, rendering, or comparison failed. Preserve
+`artifacts/parity` and link the workflow run in the investigation.
+
+## Refresh and repair
+
+For verified upstream-only drift:
+
+```bash
+pnpm run update:parity
+pnpm run verify:parity:report
+git diff -- \
+  tests/fixtures/parity-reference.css \
+  tests/fixtures/parity-reference.snapshot.json
+```
+
+For extension regressions, fix the extension first and rerun the report without changing the
+baseline. Every refresh or fix must be reviewed through a pull request with the report artifacts
+available to the reviewer.
+
+## Release
+
+The tag workflow calls the same core and host workflow at the tag SHA, then generates a fresh
+three-way report before packaging:
+
+```bash
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+gh run list --workflow publish.yml --limit 1
+```
+
+A failed or stale parity result blocks release. To make an exceptional manual release, select the
+exact tag as the workflow ref and provide all audit fields:
+
+```bash
+gh workflow run publish.yml --ref vX.Y.Z \
+  -f override_reason="Reviewed upstream-only drift; release is time critical" \
+  -f override_owner="@maintainer" \
+  -f override_report_url="https://github.com/OWNER/REPO/actions/runs/RUN_ID"
+```
+
+Partial metadata, a short reason, or a non-HTTPS report URL is rejected. The workflow uploads
+`artifacts/release-gate/audit.json`; include its run link in the release review.
+
+## Simulated recovery drill
+
+Run the deterministic detection-to-recovery drill locally or through its manual workflow:
+
+```bash
+pnpm run drill:drift
+gh workflow run drift-drill.yml --ref main
+```
+
+The drill injects `upstream-drift-with-user-impact`, verifies classification as `drift_detected`,
+simulates rollback, verifies a successful post-rollback probe, and records timestamps against the
+30-hour detection SLO in `artifacts/drift-drill`.
+
+## Rollback
+
+If a tag workflow fails before publishing, fix the cause and move only the exact unpublished tag:
+
+```bash
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+```
+
+If a GitHub Release was exposed but the Marketplace publish must be halted:
+
+```bash
+gh release edit vX.Y.Z --draft
+```
+
+Marketplace versions are not safely mutable in place. Publish a corrected patch release rather
+than deleting the entire extension. Record the failed tag, workflow, cause, owner, recovery action,
+and verification report in the tracking issue.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "verify:parity:remote": "nub scripts/parity/index.ts remote",
     "verify:parity:report": "nub scripts/parity/index.ts report",
     "probe:drift": "nub scripts/drift/index.ts",
+    "drill:drift": "nub scripts/drift/drill-index.ts",
     "i18n-export": "nubx vscode-l10n-dev export --outDir ./l10n ./src",
     "test": "vitest run",
     "test:host:build": "nub run build && nubx tsdown --config tests/host/tsdown.config.ts",

--- a/scripts/drift/drill-index.ts
+++ b/scripts/drift/drill-index.ts
@@ -1,0 +1,31 @@
+import { Buffer } from "node:buffer";
+import { registerHooks } from "node:module";
+import { join } from "node:path";
+
+const vscodeStub = `
+export const l10n = {
+  t(message, ...args) {
+    return message.replace(/\\{(\\d+)\\}/g, (_match, index) => String(args[Number(index)] ?? ""));
+  }
+};
+`;
+
+registerHooks({
+  resolve(specifier, _context, nextResolve) {
+    if (specifier !== "vscode") return nextResolve(specifier);
+    return {
+      shortCircuit: true,
+      url: `data:text/javascript;base64,${Buffer.from(vscodeStub).toString("base64")}`
+    };
+  }
+});
+
+const outputDirectory = join(process.cwd(), "artifacts", "drift-drill");
+const { writeSimulatedDriftDrill } = await import("./drill");
+const report = await writeSimulatedDriftDrill(outputDirectory);
+console.log(
+  `Simulated drift drill: detection ${report.detectionLatencySeconds}s, recovery ${report.recoveryLatencySeconds}s, SLO ${report.withinSlo ? "met" : "missed"}`
+);
+if (!report.withinSlo || report.recoveryConclusion !== "success") {
+  throw new Error(`Simulated drift drill failed. See ${outputDirectory}`);
+}

--- a/scripts/drift/drill.ts
+++ b/scripts/drift/drill.ts
@@ -1,0 +1,238 @@
+import { Buffer } from "node:buffer";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { GithubCssSnapshot } from "../build/github-css";
+import type { VisualBaseline } from "../parity/baseline";
+import { parityCases } from "../parity/cases";
+import {
+  collectThreeWayReport,
+  renderThreeWayReport,
+  ThreeWayParityReportError,
+  type ThreeWayDependencies,
+  type ThreeWayReport
+} from "../parity/three-way";
+import { createDriftReport } from "./probe";
+
+export const simulatedDriftSloSeconds = 30 * 60 * 60;
+
+export type SimulatedDriftDrillReport = {
+  schemaVersion: 1;
+  scenario: "upstream-drift-with-user-impact";
+  startedAt: string;
+  detectedAt: string;
+  classifiedAt: string;
+  alertedAt: string;
+  recoveredAt: string;
+  detectionLatencySeconds: number;
+  recoveryLatencySeconds: number;
+  sloSeconds: number;
+  withinSlo: boolean;
+  threeWayConclusion: "upstream-drift-with-user-impact";
+  detectionConclusion: "drift_detected";
+  recoveryConclusion: "success";
+  recoveryAction: "rollback-simulated-upstream-change";
+  evidence: readonly string[];
+};
+
+const snapshot: GithubCssSnapshot = {
+  schemaVersion: 1,
+  capturedAt: "2026-07-26T00:00:00.000Z",
+  extractor: {
+    package: "generate-github-markdown-css",
+    version: "simulated",
+    entryPage: "https://github.com/simulated"
+  },
+  fixtureCommit: "d".repeat(40),
+  themes: ["light", "dark"],
+  assets: [
+    {
+      url: "https://github.githubassets.com/assets/simulated-drift.css",
+      sha256: "e".repeat(64),
+      cache: { freshness: "fresh", ageSeconds: 0 },
+      signals: {
+        mediaRules: 1,
+        dataSelectors: ["data-theme"],
+        classSelectors: ["markdown-body"]
+      }
+    }
+  ],
+  filtering: {
+    input: {
+      mediaRules: 1,
+      dataSelectors: ["data-theme"],
+      classSelectors: ["markdown-body"]
+    },
+    output: {
+      mediaRules: 1,
+      dataSelectors: ["data-theme"],
+      classSelectors: ["markdown-body"]
+    },
+    excluded: { mediaRules: 0, dataSelectors: 0, classSelectors: 0 }
+  }
+};
+
+export async function createSimulatedDriftDrill(
+  startedAt = new Date(),
+  writeArtifact: ThreeWayDependencies["writeArtifact"] = async () => {}
+): Promise<SimulatedDriftDrillReport> {
+  return (await executeSimulatedDriftDrill(startedAt, writeArtifact)).report;
+}
+
+async function executeSimulatedDriftDrill(
+  startedAt: Date,
+  writeArtifact: ThreeWayDependencies["writeArtifact"]
+): Promise<{ report: SimulatedDriftDrillReport; threeWay: ThreeWayReport }> {
+  const detectedAt = new Date(startedAt.getTime() + 2_000);
+  const classifiedAt = new Date(startedAt.getTime() + 3_000);
+  const alertedAt = new Date(startedAt.getTime() + 4_000);
+  const recoveredAt = new Date(startedAt.getTime() + 8_000);
+  const threeWay = await createSimulatedThreeWayReport(writeArtifact);
+  if (threeWay.conclusion !== "upstream-drift-with-user-impact") {
+    throw new Error(`Simulated three-way report concluded ${threeWay.conclusion}`);
+  }
+  const driftError = new ThreeWayParityReportError(threeWay, "artifacts/drift-drill");
+  const detected = await createDriftReport({
+    now: detectedAt,
+    captureSnapshot: async () => snapshot,
+    verifyRemoteParity: async () => {
+      throw driftError;
+    }
+  });
+  const recovered = await createDriftReport({
+    now: recoveredAt,
+    captureSnapshot: async () => snapshot,
+    verifyRemoteParity: async () => {}
+  });
+  if (detected.conclusion !== "drift_detected" || recovered.conclusion !== "success") {
+    throw new Error(
+      "Simulated drift drill did not reach the expected detection and recovery states"
+    );
+  }
+  const detectionLatencySeconds = (detectedAt.getTime() - startedAt.getTime()) / 1_000;
+  const recoveryLatencySeconds = (recoveredAt.getTime() - startedAt.getTime()) / 1_000;
+  return {
+    threeWay,
+    report: {
+      schemaVersion: 1,
+      scenario: "upstream-drift-with-user-impact",
+      startedAt: startedAt.toISOString(),
+      detectedAt: detectedAt.toISOString(),
+      classifiedAt: classifiedAt.toISOString(),
+      alertedAt: alertedAt.toISOString(),
+      recoveredAt: recoveredAt.toISOString(),
+      detectionLatencySeconds,
+      recoveryLatencySeconds,
+      sloSeconds: simulatedDriftSloSeconds,
+      withinSlo: detectionLatencySeconds <= simulatedDriftSloSeconds,
+      threeWayConclusion: threeWay.conclusion,
+      detectionConclusion: detected.conclusion,
+      recoveryConclusion: recovered.conclusion,
+      recoveryAction: "rollback-simulated-upstream-change",
+      evidence: [
+        "Generated three-way report conclusion upstream-drift-with-user-impact",
+        "Drift probe classified the injected result as drift_detected",
+        "Emitted a simulated upstream drift workflow warning",
+        "Rolled back the simulated upstream change",
+        "Post-rollback drift probe concluded success"
+      ]
+    }
+  };
+}
+
+export function renderSimulatedDriftDrill(report: SimulatedDriftDrillReport): string {
+  return `${[
+    "# Simulated upstream drift recovery drill",
+    "",
+    `- Scenario: \`${report.scenario}\``,
+    `- Three-way report: \`${report.threeWayConclusion}\``,
+    `- Detection: \`${report.detectionConclusion}\` after ${report.detectionLatencySeconds}s`,
+    `- SLO: ${report.sloSeconds}s (${report.withinSlo ? "met" : "missed"})`,
+    `- Recovery: \`${report.recoveryConclusion}\` after ${report.recoveryLatencySeconds}s`,
+    `- Action: \`${report.recoveryAction}\``,
+    "",
+    "## Evidence",
+    "",
+    ...report.evidence.map((item) => `- ${item}`),
+    ""
+  ].join("\n")}\n`;
+}
+
+export async function writeSimulatedDriftDrill(
+  outputDirectory: string,
+  startedAt = new Date()
+): Promise<SimulatedDriftDrillReport> {
+  await mkdir(outputDirectory, { recursive: true });
+  const { report, threeWay } = await executeSimulatedDriftDrill(startedAt, (name, content) =>
+    writeFile(join(outputDirectory, name), content)
+  );
+  await Promise.all([
+    writeFile(join(outputDirectory, "report.json"), `${JSON.stringify(report, null, 2)}\n`),
+    writeFile(join(outputDirectory, "report.md"), renderSimulatedDriftDrill(report)),
+    writeFile(
+      join(outputDirectory, "three-way-report.json"),
+      `${JSON.stringify(threeWay, null, 2)}\n`
+    ),
+    writeFile(join(outputDirectory, "three-way-report.md"), renderThreeWayReport(threeWay))
+  ]);
+  return report;
+}
+
+async function createSimulatedThreeWayReport(
+  writeArtifact: ThreeWayDependencies["writeArtifact"]
+): Promise<ThreeWayReport> {
+  const selected = parityCases.filter(({ id }) => id === "stress-light" || id === "stress-dark");
+  const baseline: VisualBaseline = {
+    version: 2,
+    generatedAt: "2026-07-26T00:00:00.000Z",
+    chromiumVersion: "simulated",
+    rendererSha256: "a".repeat(64),
+    referenceCssSha256: "b".repeat(64),
+    cases: Object.fromEntries(
+      selected.map((parityCase) => [
+        parityCase.id,
+        {
+          markdownSha256: "a".repeat(64),
+          inputSha256: "b".repeat(64),
+          theme: parityCase.theme,
+          themeName: parityCase.themeName,
+          linkUnderlines: parityCase.linkUnderlines,
+          reference: parityCase.reference,
+          htmlNormalization: parityCase.htmlNormalization,
+          localComparison: parityCase.localComparison,
+          githubHtml: `<p>${parityCase.id} baseline</p>`
+        }
+      ])
+    )
+  };
+  return collectThreeWayReport(selected, {
+    fetchCurrentGithub: async () =>
+      Object.fromEntries(selected.map(({ id }) => [id, `<p>${id} current GitHub</p>`])),
+    extractInputs: async () => ({
+      baseline,
+      committedReferenceCss: "baseline css",
+      currentGithubCss: "current GitHub css",
+      currentExtensionCss: "baseline css"
+    }),
+    render: async (requests) => ({
+      chromiumVersion: "simulated",
+      screenshots: Object.fromEntries(
+        requests.map(({ id }) => [
+          id,
+          Buffer.from(id.endsWith("current-github") ? "current-github" : "baseline")
+        ])
+      )
+    }),
+    compare: (expected, actual) => {
+      const diffPixels = expected.equals(actual) ? 0 : 1;
+      return {
+        width: 1,
+        height: 1,
+        diffPixels,
+        diffPixelRatio: diffPixels,
+        largestDiffAreaPixels: diffPixels,
+        diff: Buffer.from(`diff:${diffPixels}`)
+      };
+    },
+    writeArtifact
+  });
+}

--- a/scripts/release/gate-index.ts
+++ b/scripts/release/gate-index.ts
@@ -1,0 +1,3 @@
+import { runReleaseGateCommand } from "./gate";
+
+await runReleaseGateCommand(process.argv[2] ?? "");

--- a/scripts/release/gate.ts
+++ b/scripts/release/gate.ts
@@ -1,0 +1,129 @@
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type ManualReleaseOverride =
+  | { enabled: false }
+  | { enabled: true; reason: string; owner: string; reportUrl: string };
+
+export type ReleaseGateAudit = {
+  schemaVersion: 1;
+  generatedAt: string;
+  ref: string;
+  sha: string;
+  actor: string;
+  runUrl: string;
+  override: ManualReleaseOverride;
+  parity?: {
+    outcome: string;
+    decision: "pass" | "audited-override" | "blocked";
+  };
+};
+
+type ReleaseGateEnvironment = Record<string, string | undefined>;
+
+export function resolveManualReleaseOverride(
+  reasonInput: string | undefined,
+  ownerInput: string | undefined,
+  reportUrlInput: string | undefined
+): ManualReleaseOverride {
+  const reason = reasonInput?.trim() ?? "";
+  const owner = ownerInput?.trim() ?? "";
+  const reportUrl = reportUrlInput?.trim() ?? "";
+  const supplied = [reason, owner, reportUrl].filter(Boolean).length;
+  if (supplied === 0) return { enabled: false };
+  if (supplied !== 3) {
+    throw new Error(
+      "A release gate override requires override_reason, override_owner, and override_report_url"
+    );
+  }
+  if (reason.length < 10) {
+    throw new Error("A release gate override reason must contain at least 10 characters");
+  }
+  let url: URL;
+  try {
+    url = new URL(reportUrl);
+  } catch {
+    throw new Error("A release gate override report must be a valid HTTPS URL");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("A release gate override report must be a valid HTTPS URL");
+  }
+  return { enabled: true, reason, owner, reportUrl: url.toString() };
+}
+
+export function createReleaseGateAudit(
+  environment: ReleaseGateEnvironment,
+  now = new Date()
+): ReleaseGateAudit {
+  const repository = required(environment, "GITHUB_REPOSITORY");
+  const serverUrl = required(environment, "GITHUB_SERVER_URL");
+  const runId = required(environment, "GITHUB_RUN_ID");
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    ref: required(environment, "GITHUB_REF_NAME"),
+    sha: required(environment, "GITHUB_SHA"),
+    actor: required(environment, "GITHUB_ACTOR"),
+    runUrl: `${serverUrl}/${repository}/actions/runs/${runId}`,
+    override: resolveManualReleaseOverride(
+      environment["RELEASE_GATE_OVERRIDE_REASON"],
+      environment["RELEASE_GATE_OVERRIDE_OWNER"],
+      environment["RELEASE_GATE_OVERRIDE_REPORT_URL"]
+    )
+  };
+}
+
+export function evaluateReleaseGate(
+  parityOutcome: string,
+  override: ManualReleaseOverride
+): NonNullable<ReleaseGateAudit["parity"]> {
+  if (parityOutcome === "success") return { outcome: parityOutcome, decision: "pass" };
+  if (override.enabled) return { outcome: parityOutcome, decision: "audited-override" };
+  return { outcome: parityOutcome, decision: "blocked" };
+}
+
+export async function runReleaseGateCommand(
+  command: string,
+  environment: ReleaseGateEnvironment = process.env
+): Promise<void> {
+  const directory = join(process.cwd(), "artifacts", "release-gate");
+  const auditPath = join(directory, "audit.json");
+  await mkdir(directory, { recursive: true });
+  if (command === "prepare") {
+    const audit = createReleaseGateAudit(environment);
+    await writeFile(auditPath, `${JSON.stringify(audit, null, 2)}\n`);
+    const output = environment["GITHUB_OUTPUT"];
+    if (output) {
+      await appendFile(output, `override_enabled=${String(audit.override.enabled)}\n`);
+    }
+    console.log(`Release gate audit prepared for ${audit.ref} at ${audit.sha}`);
+    return;
+  }
+  if (command === "enforce") {
+    const audit = JSON.parse(await readFile(auditPath, "utf8")) as ReleaseGateAudit;
+    audit.parity = evaluateReleaseGate(
+      environment["RELEASE_GATE_PARITY_OUTCOME"] ?? "unknown",
+      audit.override
+    );
+    await writeFile(auditPath, `${JSON.stringify(audit, null, 2)}\n`);
+    if (audit.parity.decision === "blocked") {
+      throw new Error(
+        `Fresh upstream parity concluded ${audit.parity.outcome}; an audited override was not supplied`
+      );
+    }
+    if (audit.parity.decision === "audited-override") {
+      console.warn(
+        `Release gate overridden by ${audit.override.enabled ? audit.override.owner : "unknown"}; see ${audit.runUrl}`
+      );
+    }
+    console.log(`Release gate decision: ${audit.parity.decision}`);
+    return;
+  }
+  throw new Error(`Unknown release gate command: ${command}. Expected prepare or enforce.`);
+}
+
+function required(environment: ReleaseGateEnvironment, name: string): string {
+  const value = environment[name]?.trim();
+  if (!value) throw new Error(`Missing required release gate environment variable ${name}`);
+  return value;
+}

--- a/tests/scripts/drift/drill.test.ts
+++ b/tests/scripts/drift/drill.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSimulatedDriftDrill,
+  renderSimulatedDriftDrill,
+  simulatedDriftSloSeconds
+} from "../../../scripts/drift/drill";
+
+vi.mock("vscode", () => ({ l10n: { t: (message: string) => message } }));
+
+describe("simulated upstream drift drill", () => {
+  it("detects, classifies, rolls back, and verifies recovery within the SLO", async () => {
+    const report = await createSimulatedDriftDrill(new Date("2026-07-26T00:00:00.000Z"));
+
+    expect(report).toMatchObject({
+      detectionConclusion: "drift_detected",
+      threeWayConclusion: "upstream-drift-with-user-impact",
+      recoveryConclusion: "success",
+      recoveryAction: "rollback-simulated-upstream-change",
+      detectionLatencySeconds: 2,
+      recoveryLatencySeconds: 8,
+      sloSeconds: simulatedDriftSloSeconds,
+      withinSlo: true
+    });
+    expect(renderSimulatedDriftDrill(report)).toContain("SLO: 108000s (met)");
+  });
+});

--- a/tests/scripts/release/gate.test.ts
+++ b/tests/scripts/release/gate.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  createReleaseGateAudit,
+  evaluateReleaseGate,
+  resolveManualReleaseOverride
+} from "../../../scripts/release/gate";
+
+describe("release gate", () => {
+  it("requires complete audited override metadata", () => {
+    expect(resolveManualReleaseOverride(undefined, undefined, undefined)).toEqual({
+      enabled: false
+    });
+    expect(() =>
+      resolveManualReleaseOverride("GitHub drift accepted", "maintainer", undefined)
+    ).toThrow(/requires override_reason, override_owner, and override_report_url/);
+    expect(() =>
+      resolveManualReleaseOverride(
+        "Reviewed upstream-only visual drift",
+        "maintainer",
+        "http://example.com/report"
+      )
+    ).toThrow(/valid HTTPS URL/);
+  });
+
+  it("records the tag SHA, actor, workflow, and override evidence", () => {
+    const audit = createReleaseGateAudit(
+      {
+        GITHUB_REPOSITORY: "example/repository",
+        GITHUB_SERVER_URL: "https://github.com",
+        GITHUB_RUN_ID: "123",
+        GITHUB_REF_NAME: "v4.4.0",
+        GITHUB_SHA: "a".repeat(40),
+        GITHUB_ACTOR: "maintainer",
+        RELEASE_GATE_OVERRIDE_REASON: "Reviewed upstream-only visual drift",
+        RELEASE_GATE_OVERRIDE_OWNER: "@maintainer",
+        RELEASE_GATE_OVERRIDE_REPORT_URL: "https://github.com/example/repository/actions/runs/122"
+      },
+      new Date("2026-07-26T00:00:00.000Z")
+    );
+
+    expect(audit).toMatchObject({
+      generatedAt: "2026-07-26T00:00:00.000Z",
+      ref: "v4.4.0",
+      sha: "a".repeat(40),
+      actor: "maintainer",
+      runUrl: "https://github.com/example/repository/actions/runs/123",
+      override: {
+        enabled: true,
+        owner: "@maintainer"
+      }
+    });
+  });
+
+  it("blocks a failed parity result unless the override is audited", () => {
+    expect(evaluateReleaseGate("success", { enabled: false }).decision).toBe("pass");
+    expect(evaluateReleaseGate("failure", { enabled: false }).decision).toBe("blocked");
+    expect(
+      evaluateReleaseGate("failure", {
+        enabled: true,
+        reason: "Reviewed upstream-only visual drift",
+        owner: "@maintainer",
+        reportUrl: "https://example.com/report"
+      }).decision
+    ).toBe("audited-override");
+  });
+});


### PR DESCRIPTION
## Summary

- make the core CI workflow reusable and run it at the release tag SHA before publishing
- require a fresh three-way upstream parity report, with complete audited metadata for any manual override
- version the `main` ruleset, add a deterministic upstream-drift recovery drill, and document recovery and rollback

## Why

The v4.4.0 release process had monitoring and three-way diagnostics, but `main` and tag publishing did not yet enforce those checks or preserve an operator-ready recovery path.

## Impact

Release tags are blocked when core/host checks or fresh upstream parity fail. Exceptional overrides require a reason, accountable owner, and HTTPS report link. Maintainers gain a repeatable recovery drill and runbook; extension runtime behavior is unchanged.

## Validation

- `nub run test` — 232 tests passed
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `tsc --noEmit`
- `nub run build`
- `nub run package`
- `pnpm run drill:drift` — detection 2s, recovery 8s, 30-hour SLO met
- targeted release-gate, drift, and three-way tests — 18 passed
- workflow YAML and ruleset JSON parsed successfully

Local `verify:parity` was attempted but could not run because the Playwright Chromium binary is not installed locally; CI installs Chromium before executing the same check.

Closes #1143