### PR TITLE
fix(parity): accept GitHub CSS module assets

### DIFF
--- a/scripts/build/github-css.ts
+++ b/scripts/build/github-css.ts
@@ -410,7 +410,7 @@ async function captureCachedGitHubCssAssets(
 
 function hasStableGithubCssAssetName(url: string): boolean {
   try {
-    return /\/[-\w]+-\w+\.css$/i.test(new URL(url).pathname);
+    return /\/(?:[-\w]+-\w+|[-\w]+\.[\da-f]{16}\.module)\.css$/i.test(new URL(url).pathname);
   } catch {
     return false;
   }

--- a/tests/scripts/build/github-css.test.ts
+++ b/tests/scripts/build/github-css.test.ts
@@ -108,6 +108,9 @@ describe("GitHub CSS assets", () => {
     const generator = vi.fn<GithubCssGenerator>(async (options) => {
       if (options.onlyStyles) {
         await globalThis.fetch("https://github.githubassets.com/assets/primer-123abc.css");
+        await globalThis.fetch(
+          "https://github.githubassets.com/assets/primer-react-css.98ad1672d1ed9f02.module.css"
+        );
         return ".vscode-github-markdown { color: inherit; }";
       }
       const theme = String(options.light);
@@ -133,16 +136,22 @@ describe("GitHub CSS assets", () => {
           cache: { freshness: "fresh", ageSeconds: 0 },
           etag: '"css-etag"',
           signals: { mediaRules: 1, dataSelectors: ["data-preview"], classSelectors: ["unknown"] }
+        },
+        {
+          url: "https://github.githubassets.com/assets/primer-react-css.98ad1672d1ed9f02.module.css",
+          cache: { freshness: "fresh", ageSeconds: 0 },
+          etag: '"css-etag"',
+          signals: { mediaRules: 1, dataSelectors: ["data-preview"], classSelectors: ["unknown"] }
         }
       ]);
-      expect(snapshot.assets[0]?.sha256).toMatch(/^[\da-f]{64}$/);
-      expect(snapshot.filtering.excluded).toMatchObject({ mediaRules: 1, dataSelectors: 1 });
+      expect(snapshot.assets.every(({ sha256 }) => /^[\da-f]{64}$/.test(sha256))).toBe(true);
+      expect(snapshot.filtering.excluded).toMatchObject({ mediaRules: 2, dataSelectors: 1 });
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  it("rejects a new CSS asset-name convention with structured source signals", async () => {
+  it("rejects an unhashed CSS module asset name with structured source signals", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = vi.fn(
       async () => new Response('@media screen { [data-preview="true"] .unknown { color: red; } }')
@@ -150,7 +159,7 @@ describe("GitHub CSS assets", () => {
     const generator = vi.fn<GithubCssGenerator>(async (options) => {
       if (options.onlyStyles) {
         await globalThis.fetch(
-          "https://github.githubassets.com/assets/primer-react-css.98ad1672d1ed9f02.module.css"
+          "https://github.githubassets.com/assets/primer-react-css.module.css"
         );
         return ".vscode-github-markdown { color: inherit; }";
       }


### PR DESCRIPTION
## Summary

- accept GitHub's current `name.<16-hex>.module.css` asset convention while preserving the legacy hashed form
- continue rejecting unhashed CSS Module assets as unsupported extractor input
- cover both accepted conventions and the rejected unhashed form

## Root cause

The first real upstream drift probe reached GitHub successfully, but its provenance contract rejected ten valid CSS Module assets before the three-way comparison. See [Actions run 30176652859](https://github.com/lzm0x219/vscode-github-markdown/actions/runs/30176652859).

## Impact

The independent drift probe can inspect GitHub's current CSS asset set without weakening the contract to arbitrary filenames. Extension runtime behavior is unchanged.

## Validation

- `nub run test` — 232 tests passed
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `tsc --noEmit`
- `nubx oxfmt --check scripts/build/github-css.ts tests/scripts/build/github-css.test.ts`
- `git diff --check`

Closes #1188