### PR TITLE
docs: explain v4.4 preview reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+Upcoming changes strengthen preview reliability as GitHub's styles evolve. They do not change current Markdown rendering, settings, or supported VS Code versions.
+
+### Markdown preview
+
+- Extension updates now stop when current GitHub rendering differs from the supported desktop or web preview, preventing an unreviewed mismatch from reaching users.
+- GitHub-side style changes and extension regressions are now identified separately, so compatibility fixes can address the source of a mismatch before publication.
+
 ## [v4.3.0] - 2026-07-19
 
 v4.3.0 makes GitHub Markdown previews follow VS Code color themes more naturally across desktop and web while preserving readable high-contrast and fixed Single mode behavior. Mermaid diagrams now stay synchronized with both built-in and external renderers.


### PR DESCRIPTION
## Summary

- add a user-facing `[Unreleased]` summary for the v4.4 preview reliability work
- explain that unreviewed GitHub rendering differences block extension releases
- clarify that current rendering, settings, and supported VS Code versions remain unchanged

## Why

The v4.4 work completed its upstream drift and release safeguards, but the changelog did not yet explain the resulting reliability outcome or whether users need to take action.

## Impact

Users can see that future extension updates are checked against current GitHub rendering across supported desktop and web hosts. No migration or settings change is required.

## Validation

- `nubx oxfmt --check CHANGELOG.md`
- `pnpm exec vitest run tests/scripts/release/changelog.test.ts tests/scripts/release/index.test.ts` — 9 tests passed
- `git diff --check`

Closes #1190