### PR TITLE
ci: compare VSIX package size

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,0 +1,94 @@
+name: Package Size
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    name: Package (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: baseline
+            ref: ${{ github.event.pull_request.base.sha }}
+          - name: current
+            ref: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.ref }}
+
+      - uses: jdx/mise-action@v4
+
+      - name: Install nub
+        run: npm install --global @nubjs/nub
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: nub run build
+
+      - name: Package
+        run: nub run package
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-size-${{ matrix.name }}
+          path: "*.vsix"
+          if-no-files-found: error
+          retention-days: 7
+
+  compare:
+    name: Compare
+    needs: package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: jdx/mise-action@v4
+
+      - name: Install nub
+        run: npm install --global @nubjs/nub
+
+      - name: Download baseline VSIX
+        uses: actions/download-artifact@v8
+        with:
+          name: package-size-baseline
+          path: artifacts/packages/baseline
+
+      - name: Download current VSIX
+        uses: actions/download-artifact@v8
+        with:
+          name: package-size-current
+          path: artifacts/packages/current
+
+      - name: Compare package size and contents
+        run: |
+          nub scripts/package-audit/index.ts \
+            artifacts/packages/baseline/*.vsix \
+            artifacts/packages/current/*.vsix \
+            artifacts/package-size/report.json
+
+      - name: Upload package audit
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-size-report
+          path: artifacts/package-size
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,30 +128,16 @@ jobs:
         run: nub run package
 
       - name: Verify VSIX contents and size
-        shell: bash
         run: |
           archive="$(find . -maxdepth 1 -type f -name '*.vsix' -print -quit)"
           if [[ -z "$archive" ]]; then
             echo "::error::No VSIX archive was produced"
             exit 1
           fi
-
-          archive_size="$(stat --format=%s "$archive")"
-          maximum_size=$((512 * 1024))
-          if (( archive_size > maximum_size )); then
-            echo "::error::VSIX size ${archive_size} bytes exceeds the ${maximum_size}-byte budget"
-            exit 1
-          fi
-
-          forbidden_files="$(
-            unzip -Z1 "$archive" |
-              grep -E '^extension/(\.serena/|release-CHANGELOG\.txt$)' || true
-          )"
-          if [[ -n "$forbidden_files" ]]; then
-            echo "::error::VSIX contains forbidden files"
-            echo "$forbidden_files"
-            exit 1
-          fi
+          nub scripts/package-audit/index.ts \
+            "$archive" \
+            "$archive" \
+            artifacts/package-size/release.json
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v7
@@ -160,6 +146,7 @@ jobs:
           path: |
             *.vsix
             release-CHANGELOG.txt
+            artifacts/package-size/release.json
           if-no-files-found: error
           retention-days: 14
 

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,6 +20,10 @@ ARCHITECTURE.md
 CONTRIBUTING.md
 artifacts/**
 artifacts
+assets/parity-github.png
+assets/parity-vscode.png
+assets/readme-banner-dark.jpg
+assets/readme-banner.jpg
 coverage/**
 coverage
 lefthook.yml

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./assets/readme-banner-dark.jpg">
-    <source media="(prefers-color-scheme: light)" srcset="./assets/readme-banner.jpg">
-    <img alt="Isometric Markdown source and GitHub preview connected by green contribution blocks" src="./assets/readme-banner.jpg">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/readme-banner-dark.jpg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/readme-banner.jpg">
+    <img alt="Isometric Markdown source and GitHub preview connected by green contribution blocks" src="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/readme-banner.jpg">
   </picture>
 </p>
 
@@ -43,8 +43,8 @@ Open a Markdown file, then run **Markdown: Open Preview to the Side**. The built
     <th>Extension renderer</th>
   </tr>
   <tr>
-    <td><img alt="Markdown rendered by GitHub" src="./assets/parity-github.png" /></td>
-    <td><img alt="Markdown rendered by the extension pipeline" src="./assets/parity-vscode.png" /></td>
+    <td><img alt="Markdown rendered by GitHub" src="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/parity-github.png" /></td>
+    <td><img alt="Markdown rendered by the extension pipeline" src="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/parity-vscode.png" /></td>
   </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,9 +4,9 @@
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="./assets/readme-banner-dark.jpg">
-    <source media="(prefers-color-scheme: light)" srcset="./assets/readme-banner.jpg">
-    <img alt="Markdown 源码与 GitHub 预览通过绿色贡献方块连接的等距插图" src="./assets/readme-banner.jpg">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/readme-banner-dark.jpg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/readme-banner.jpg">
+    <img alt="Markdown 源码与 GitHub 预览通过绿色贡献方块连接的等距插图" src="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/readme-banner.jpg">
   </picture>
 </p>
 
@@ -43,8 +43,8 @@ code --install-extension lzm0x219.vscode-github-markdown
     <th>扩展渲染管线</th>
   </tr>
   <tr>
-    <td><img alt="GitHub 渲染的 Markdown" src="./assets/parity-github.png" /></td>
-    <td><img alt="扩展管线渲染的 Markdown" src="./assets/parity-vscode.png" /></td>
+    <td><img alt="GitHub 渲染的 Markdown" src="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/parity-github.png" /></td>
+    <td><img alt="扩展管线渲染的 Markdown" src="https://raw.githubusercontent.com/lzm0x219/vscode-github-markdown/main/assets/parity-vscode.png" /></td>
   </tr>
 </table>
 

--- a/scripts/package-audit/archive.ts
+++ b/scripts/package-audit/archive.ts
@@ -1,0 +1,26 @@
+import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { promisify } from "node:util";
+import type { PackageSnapshot } from "./audit";
+
+const execFileAsync = promisify(execFile);
+
+export function parseZipListing(listing: string, archiveBytes: number): PackageSnapshot {
+  const entries: Record<string, number> = {};
+  for (const line of listing.split("\n")) {
+    const match = /^\s*(\d+)\s+\S+\s+\S+\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const [, size, path] = match;
+    if (!size || !path || path.endsWith("/")) continue;
+    entries[path] = Number(size);
+  }
+  return { archiveBytes, entries };
+}
+
+export async function readPackageSnapshot(path: string): Promise<PackageSnapshot> {
+  const [{ size }, { stdout }] = await Promise.all([
+    stat(path),
+    execFileAsync("unzip", ["-l", path], { encoding: "utf8" })
+  ]);
+  return parseZipListing(stdout, size);
+}

--- a/scripts/package-audit/audit.ts
+++ b/scripts/package-audit/audit.ts
@@ -1,0 +1,96 @@
+export type PackageSnapshot = {
+  archiveBytes: number;
+  entries: Readonly<Record<string, number>>;
+};
+
+export type PackageEntryIncrease = {
+  path: string;
+  baselineBytes: number;
+  currentBytes: number;
+  deltaBytes: number;
+};
+
+export type PackageAuditReport = {
+  conclusion: "pass" | "fail";
+  baseline: PackageSnapshot;
+  current: PackageSnapshot;
+  archiveDeltaBytes: number;
+  archiveDeltaRatio: number;
+  largestEntryIncreases: PackageEntryIncrease[];
+  violations: PackageAuditViolation[];
+};
+
+export type PackageAuditViolation =
+  | {
+      rule: "maximum-size" | "maximum-increase-bytes" | "maximum-increase-ratio";
+      actual: number;
+      limit: number;
+    }
+  | { rule: "forbidden-file"; path: string };
+
+export const maximumPackageBytes = 512 * 1024;
+export const maximumPackageIncreaseBytes = 64 * 1024;
+export const maximumPackageIncreaseRatio = 0.2;
+const forbiddenPackageFiles = new Set([
+  "extension/assets/parity-github.png",
+  "extension/assets/parity-vscode.png",
+  "extension/assets/readme-banner-dark.jpg",
+  "extension/assets/readme-banner.jpg",
+  "extension/release-CHANGELOG.txt"
+]);
+
+export function auditPackageComparison(
+  baseline: PackageSnapshot,
+  current: PackageSnapshot
+): PackageAuditReport {
+  const archiveDeltaBytes = current.archiveBytes - baseline.archiveBytes;
+  const archiveDeltaRatio =
+    baseline.archiveBytes === 0 ? 0 : archiveDeltaBytes / baseline.archiveBytes;
+  const largestEntryIncreases = Object.entries(current.entries)
+    .map(([path, currentBytes]) => {
+      const baselineBytes = baseline.entries[path] ?? 0;
+      return { path, baselineBytes, currentBytes, deltaBytes: currentBytes - baselineBytes };
+    })
+    .filter(({ deltaBytes }) => deltaBytes > 0)
+    .sort(
+      (left, right) => right.deltaBytes - left.deltaBytes || left.path.localeCompare(right.path)
+    )
+    .slice(0, 10);
+  const violations: PackageAuditViolation[] = [];
+  if (current.archiveBytes > maximumPackageBytes) {
+    violations.push({
+      rule: "maximum-size",
+      actual: current.archiveBytes,
+      limit: maximumPackageBytes
+    });
+  }
+  if (archiveDeltaBytes > maximumPackageIncreaseBytes) {
+    violations.push({
+      rule: "maximum-increase-bytes",
+      actual: archiveDeltaBytes,
+      limit: maximumPackageIncreaseBytes
+    });
+  }
+  if (archiveDeltaRatio > maximumPackageIncreaseRatio) {
+    violations.push({
+      rule: "maximum-increase-ratio",
+      actual: archiveDeltaRatio,
+      limit: maximumPackageIncreaseRatio
+    });
+  }
+  for (const path of Object.keys(current.entries).sort()) {
+    if (path.startsWith("extension/.serena/") || forbiddenPackageFiles.has(path)) {
+      violations.push({ rule: "forbidden-file", path });
+    }
+  }
+
+  return {
+    conclusion: violations.length === 0 ? "pass" : "fail",
+    baseline,
+    current,
+    archiveDeltaBytes,
+    archiveDeltaRatio,
+    largestEntryIncreases,
+    violations
+  };
+}

--- a/scripts/package-audit/cli.ts
+++ b/scripts/package-audit/cli.ts
@@ -1,0 +1,40 @@
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { readPackageSnapshot } from "./archive";
+import { auditPackageComparison, type PackageSnapshot } from "./audit";
+import { renderPackageAuditReport } from "./report";
+
+type PackageAuditOptions = {
+  baselinePath: string;
+  currentPath: string;
+  outputPath: string;
+  summaryPath?: string;
+  readSnapshot?: (path: string) => Promise<PackageSnapshot>;
+};
+
+export class PackageAuditError extends Error {
+  constructor() {
+    super("VSIX package audit failed");
+    this.name = "PackageAuditError";
+  }
+}
+
+export async function runPackageAudit(options: PackageAuditOptions): Promise<void> {
+  const readSnapshot = options.readSnapshot ?? readPackageSnapshot;
+  const [baseline, current] = await Promise.all([
+    readSnapshot(options.baselinePath),
+    readSnapshot(options.currentPath)
+  ]);
+  const report = auditPackageComparison(baseline, current);
+  const markdown = renderPackageAuditReport(report);
+
+  await mkdir(dirname(options.outputPath), { recursive: true });
+  await writeFile(
+    options.outputPath,
+    `${JSON.stringify({ schemaVersion: 1, ...report }, null, 2)}\n`
+  );
+  if (options.summaryPath) await appendFile(options.summaryPath, markdown);
+  console.log(markdown);
+
+  if (report.conclusion === "fail") throw new PackageAuditError();
+}

--- a/scripts/package-audit/index.ts
+++ b/scripts/package-audit/index.ts
@@ -1,0 +1,15 @@
+import { runPackageAudit } from "./cli";
+
+const [baselinePath, currentPath, outputPath] = process.argv.slice(2);
+if (!baselinePath || !currentPath || !outputPath) {
+  throw new Error(
+    "Usage: nub scripts/package-audit/index.ts <baseline.vsix> <current.vsix> <report.json>"
+  );
+}
+
+await runPackageAudit({
+  baselinePath,
+  currentPath,
+  outputPath,
+  ...(process.env["GITHUB_STEP_SUMMARY"] ? { summaryPath: process.env["GITHUB_STEP_SUMMARY"] } : {})
+});

--- a/scripts/package-audit/report.ts
+++ b/scripts/package-audit/report.ts
@@ -1,0 +1,65 @@
+import type { PackageAuditReport, PackageAuditViolation } from "./audit";
+
+const numberFormat = new Intl.NumberFormat("en-US");
+
+export function renderPackageAuditReport(report: PackageAuditReport): string {
+  const lines = [
+    "# VSIX package size",
+    "",
+    `Conclusion: **${report.conclusion.toUpperCase()}**`,
+    "",
+    "| Package | Size |",
+    "| --- | ---: |",
+    `| Baseline | ${formatBytes(report.baseline.archiveBytes)} |`,
+    `| Current | ${formatBytes(report.current.archiveBytes)} |`,
+    `| Change | ${formatSignedBytes(report.archiveDeltaBytes)} (${formatSignedPercent(report.archiveDeltaRatio)}) |`
+  ];
+
+  if (report.violations.length > 0) {
+    lines.push(
+      "",
+      "## Violations",
+      "",
+      ...report.violations.map((violation) => `- ${renderViolation(violation)}`)
+    );
+  }
+
+  lines.push("", "## Largest file increases", "", "| File | Baseline | Current | Change |");
+  lines.push("| --- | ---: | ---: | ---: |");
+  if (report.largestEntryIncreases.length === 0) {
+    lines.push("| No file increases | — | — | — |");
+  } else {
+    for (const entry of report.largestEntryIncreases) {
+      lines.push(
+        `| \`${entry.path.replaceAll("|", "\\|")}\` | ${formatBytes(entry.baselineBytes)} | ${formatBytes(entry.currentBytes)} | ${formatSignedBytes(entry.deltaBytes)} |`
+      );
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function renderViolation(violation: PackageAuditViolation): string {
+  if (violation.rule === "forbidden-file") {
+    return `Forbidden package file: \`${violation.path}\`.`;
+  }
+  if (violation.rule === "maximum-increase-ratio") {
+    return `Package increase ${formatPercent(violation.actual)} exceeds ${formatPercent(violation.limit)}.`;
+  }
+  return `${violation.rule === "maximum-size" ? "Package size" : "Package increase"} ${formatBytes(violation.actual)} exceeds ${formatBytes(violation.limit)}.`;
+}
+
+function formatBytes(value: number): string {
+  return `${numberFormat.format(value)} B`;
+}
+
+function formatSignedBytes(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatBytes(value)}`;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function formatSignedPercent(value: number): string {
+  return `${value >= 0 ? "+" : ""}${formatPercent(value)}`;
+}

--- a/tests/scripts/package-audit/archive.test.ts
+++ b/tests/scripts/package-audit/archive.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseZipListing } from "../../../scripts/package-audit/archive";
+
+describe("parseZipListing", () => {
+  it("creates a package snapshot from an unzip listing", () => {
+    const snapshot = parseZipListing(
+      `Archive:  current.vsix
+  Length      Date    Time    Name
+---------  ---------- -----   ----
+   105000  07-26-2026 07:00   extension/dist/extension.js
+    10000  07-26-2026 07:00   extension/readme.md
+---------                     -------
+   115000                     2 files
+`,
+      42_000
+    );
+
+    expect(snapshot).toEqual({
+      archiveBytes: 42_000,
+      entries: {
+        "extension/dist/extension.js": 105_000,
+        "extension/readme.md": 10_000
+      }
+    });
+  });
+});

--- a/tests/scripts/package-audit/audit.test.ts
+++ b/tests/scripts/package-audit/audit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { auditPackageComparison } from "../../../scripts/package-audit/audit";
+
+describe("auditPackageComparison", () => {
+  it("passes a small package increase and reports its exact delta", () => {
+    const report = auditPackageComparison(
+      {
+        archiveBytes: 200_000,
+        entries: {
+          "extension/dist/extension.js": 100_000,
+          "extension/readme.md": 10_000
+        }
+      },
+      {
+        archiveBytes: 210_000,
+        entries: {
+          "extension/dist/extension.js": 105_000,
+          "extension/readme.md": 10_000
+        }
+      }
+    );
+
+    expect(report.conclusion).toBe("pass");
+    expect(report.archiveDeltaBytes).toBe(10_000);
+    expect(report.archiveDeltaRatio).toBe(0.05);
+    expect(report.largestEntryIncreases[0]).toEqual({
+      path: "extension/dist/extension.js",
+      baselineBytes: 100_000,
+      currentBytes: 105_000,
+      deltaBytes: 5_000
+    });
+  });
+
+  it("fails when the current package exceeds 512 KiB", () => {
+    const report = auditPackageComparison(
+      { archiveBytes: 500_000, entries: {} },
+      { archiveBytes: 524_289, entries: {} }
+    );
+
+    expect(report.conclusion).toBe("fail");
+    expect(report.violations).toContainEqual({
+      rule: "maximum-size",
+      actual: 524_289,
+      limit: 524_288
+    });
+  });
+
+  it("fails when package growth exceeds 64 KiB", () => {
+    const report = auditPackageComparison(
+      { archiveBytes: 400_000, entries: {} },
+      { archiveBytes: 465_537, entries: {} }
+    );
+
+    expect(report.violations).toContainEqual({
+      rule: "maximum-increase-bytes",
+      actual: 65_537,
+      limit: 65_536
+    });
+  });
+
+  it("fails when package growth exceeds 20 percent", () => {
+    const report = auditPackageComparison(
+      { archiveBytes: 100_000, entries: {} },
+      { archiveBytes: 120_001, entries: {} }
+    );
+
+    expect(report.violations).toContainEqual({
+      rule: "maximum-increase-ratio",
+      actual: 0.20001,
+      limit: 0.2
+    });
+  });
+
+  it("fails when the current package contains forbidden files", () => {
+    const report = auditPackageComparison(
+      { archiveBytes: 200_000, entries: {} },
+      {
+        archiveBytes: 200_000,
+        entries: {
+          "extension/.serena/project.yml": 9_375,
+          "extension/assets/parity-github.png": 9_879,
+          "extension/assets/readme-banner.jpg": 79_611,
+          "extension/release-CHANGELOG.txt": 526
+        }
+      }
+    );
+
+    expect(report.violations).toEqual([
+      { rule: "forbidden-file", path: "extension/.serena/project.yml" },
+      { rule: "forbidden-file", path: "extension/assets/parity-github.png" },
+      { rule: "forbidden-file", path: "extension/assets/readme-banner.jpg" },
+      { rule: "forbidden-file", path: "extension/release-CHANGELOG.txt" }
+    ]);
+  });
+});

--- a/tests/scripts/package-audit/cli.test.ts
+++ b/tests/scripts/package-audit/cli.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PackageSnapshot } from "../../../scripts/package-audit/audit";
+import { PackageAuditError, runPackageAudit } from "../../../scripts/package-audit/cli";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("runPackageAudit", () => {
+  it("writes JSON and Markdown reports for a passing comparison", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "package-audit-"));
+    temporaryDirectories.push(directory);
+    const outputPath = join(directory, "report.json");
+    const summaryPath = join(directory, "summary.md");
+    const snapshots: Record<string, PackageSnapshot> = {
+      baseline: { archiveBytes: 200_000, entries: {} },
+      current: { archiveBytes: 210_000, entries: {} }
+    };
+
+    await runPackageAudit({
+      baselinePath: "baseline",
+      currentPath: "current",
+      outputPath,
+      summaryPath,
+      readSnapshot: async (path) => snapshots[path]!
+    });
+
+    expect(JSON.parse(await readFile(outputPath, "utf8"))).toMatchObject({
+      conclusion: "pass",
+      archiveDeltaBytes: 10_000
+    });
+    expect(await readFile(summaryPath, "utf8")).toContain("Conclusion: **PASS**");
+  });
+
+  it("writes the reports before failing a blocked comparison", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "package-audit-"));
+    temporaryDirectories.push(directory);
+    const outputPath = join(directory, "report.json");
+    const summaryPath = join(directory, "summary.md");
+
+    await expect(
+      runPackageAudit({
+        baselinePath: "baseline",
+        currentPath: "current",
+        outputPath,
+        summaryPath,
+        readSnapshot: async (path) =>
+          path === "baseline"
+            ? { archiveBytes: 200_000, entries: {} }
+            : { archiveBytes: 600_000, entries: {} }
+      })
+    ).rejects.toBeInstanceOf(PackageAuditError);
+
+    expect(JSON.parse(await readFile(outputPath, "utf8"))).toMatchObject({
+      conclusion: "fail"
+    });
+    expect(await readFile(summaryPath, "utf8")).toContain("Conclusion: **FAIL**");
+  });
+});

--- a/tests/scripts/package-audit/report.test.ts
+++ b/tests/scripts/package-audit/report.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { auditPackageComparison } from "../../../scripts/package-audit/audit";
+import { renderPackageAuditReport } from "../../../scripts/package-audit/report";
+
+describe("renderPackageAuditReport", () => {
+  it("renders the package comparison and largest file increases for the job summary", () => {
+    const report = auditPackageComparison(
+      {
+        archiveBytes: 200_000,
+        entries: { "extension/dist/extension.js": 100_000 }
+      },
+      {
+        archiveBytes: 210_000,
+        entries: { "extension/dist/extension.js": 105_000 }
+      }
+    );
+
+    const markdown = renderPackageAuditReport(report);
+
+    expect(markdown).toContain("# VSIX package size");
+    expect(markdown).toContain("| Baseline | 200,000 B |");
+    expect(markdown).toContain("| Current | 210,000 B |");
+    expect(markdown).toContain("| Change | +10,000 B (+5.00%) |");
+    expect(markdown).toContain(
+      "| `extension/dist/extension.js` | 100,000 B | 105,000 B | +5,000 B |"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- build baseline and current VSIX archives for every pull request
- compare total size, byte and percentage changes, and the ten largest file increases
- fail on packages above 512 KiB, increases above 64 KiB or 20%, and forbidden package files
- publish JSON evidence and a GitHub Job Summary
- reuse the same audit implementation during release publishing
- load README artwork from GitHub-hosted URLs so README-only images stay out of the VSIX

## Impact

Package regressions are visible before merge instead of only during release. The rebuilt VSIX contains 24 files and is 76,720 bytes; `assets/icon.png` is the only packaged image asset.

## Validation

- 241 tests passed
- `nubx oxlint .`
- `nubx oxlint --type-aware .`
- `nubx oxfmt --check .`
- `nub run package`
- local package audit passed and wrote JSON plus Markdown output
- all four GitHub-hosted README image URLs returned HTTP 200

Closes #1197