### PR TITLE
docs: prepare v4.4.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+## [v4.4.1] - 2026-07-26
+
+v4.4.1 makes extension downloads and updates substantially smaller without changing Markdown preview behavior, settings, or supported VS Code versions.
+
 ### Installation and compatibility
 
 - Extension downloads and updates now use a substantially smaller package while keeping the same light and dark README artwork and Markdown preview behavior.
@@ -113,10 +117,11 @@ v4 is a new extension rather than an in-place update of `lzm0x219.vscode-markdow
 - v4 supports VS Code 1.74 or later and continues to enhance the built-in Markdown preview instead of opening a separate preview editor.
 - Commands and settings are available in English and Simplified Chinese according to the VS Code display language.
 
+[v4.4.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.0...v4.4.1
 [v4.4.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.3.0...v4.4.0
 [v4.3.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.2.0...v4.3.0
 [v4.2.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.1.1...v4.2.0
 [v4.1.1]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.1.0...v4.1.1
 [v4.1.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.0.0...v4.1.0
 [v4.0.0]: https://github.com/lzm0x219/vscode-github-markdown/compare/v3.1.0...v4.0.0
-[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/lzm0x219/vscode-github-markdown/compare/v4.4.1...HEAD


### PR DESCRIPTION
## Summary

- promote the package-size improvement from `[Unreleased]` into a dated `v4.4.1` section
- add a concise user-facing release summary
- update the `v4.4.1` and `[Unreleased]` comparison links

## Validation

- release and changelog tests — 12 passed
- v4.4.1 release-note extraction produced a complete standalone entry
- `nubx oxfmt CHANGELOG.md`
- `git diff --check`

Closes #1199