### PR TITLE
fix: preserve Mermaid settings after partial sync failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file records notable changes that people can observe or act on when using t
 
 ## [Unreleased]
 
+### Mermaid
+
+- Mermaid theme synchronization now restores any setting it changed when a partial update fails, preserving your previous light and dark theme choices.
+
 ## [v4.4.1] - 2026-07-26
 
 v4.4.1 makes extension downloads and updates substantially smaller without changing Markdown preview behavior, settings, or supported VS Code versions.

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -27,8 +27,8 @@ type MermaidThemeSnapshot = {
   light: MermaidTheme | undefined;
   dark: MermaidTheme | undefined;
   applied?: {
-    light: MermaidTheme;
-    dark: MermaidTheme;
+    light?: MermaidTheme;
+    dark?: MermaidTheme;
   };
 };
 
@@ -58,14 +58,26 @@ export async function updateMermaidThemeSync(memento: vscode.Memento): Promise<v
 
   const snapshot = await preserveMermaidThemes(memento, configuration);
   const [light, dark] = resolveMermaidThemes();
-  await Promise.all([
+  const [lightResult, darkResult] = await Promise.allSettled([
     updateMermaidTheme(configuration, originSection.light, light),
     updateMermaidTheme(configuration, originSection.dark, dark)
   ]);
+  const applied = { ...snapshot.applied };
+  if (lightResult.status === "fulfilled") {
+    applied.light = light;
+  }
+  if (darkResult.status === "fulfilled") {
+    applied.dark = dark;
+  }
   await memento.update(snapshotKey, {
     ...snapshot,
-    applied: { light, dark }
+    applied
   } satisfies MermaidThemeSnapshot);
+
+  const failure = [lightResult, darkResult].find((result) => result.status === "rejected");
+  if (failure?.status === "rejected") {
+    throw failure.reason;
+  }
 }
 
 export async function restoreMermaidThemeSync(
@@ -79,13 +91,13 @@ export async function restoreMermaidThemeSync(
 
   const updates: Promise<void>[] = [];
   if (
-    snapshot.applied &&
+    snapshot.applied?.light !== undefined &&
     getGlobalMermaidTheme(configuration, originSection.light) === snapshot.applied.light
   ) {
     updates.push(updateMermaidTheme(configuration, originSection.light, snapshot.light));
   }
   if (
-    snapshot.applied &&
+    snapshot.applied?.dark !== undefined &&
     getGlobalMermaidTheme(configuration, originSection.dark) === snapshot.applied.dark
   ) {
     updates.push(updateMermaidTheme(configuration, originSection.dark, snapshot.dark));

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -17,6 +17,8 @@ let mermaidConfigurationRegistered = true;
 let mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
 
 const updateCalls: { key: string; value: string | undefined; target: number }[] = [];
+let updateFailures = new Set<string>();
+let updateGates = new Map<string, Promise<void>>();
 
 vi.mock("vscode", () => ({
   default: {
@@ -34,6 +36,13 @@ vi.mock("vscode", () => ({
                 : undefined,
             update: async (key: string, value: string | undefined, target: number) => {
               updateCalls.push({ key, value, target });
+              if (updateFailures.has(key)) {
+                throw new Error(`Failed to update ${key}`);
+              }
+              const updateGate = updateGates.get(key);
+              if (updateGate) {
+                await updateGate;
+              }
               mermaidGlobalConfig[key] = value;
             }
           };
@@ -65,6 +74,8 @@ describe("Mermaid theme synchronization", () => {
     };
     mermaidConfigurationRegistered = true;
     mermaidExtensionIds = new Set(["vscode.mermaid-markdown-features"]);
+    updateFailures = new Set();
+    updateGates = new Map();
   });
 
   it("configures both Mermaid slots from the system-mode light and dark themes", async () => {
@@ -145,6 +156,35 @@ describe("Mermaid theme synchronization", () => {
     expect(updateCalls).toEqual([{ key: "darkModeTheme", value: "forest", target: 1 }]);
     expect(mermaidGlobalConfig).toEqual({
       lightModeTheme: "base",
+      darkModeTheme: "forest"
+    });
+  });
+
+  it("restores a setting changed before another theme update fails", async () => {
+    const memento = createTestMemento();
+    let releaseLightUpdate = () => {};
+    updateGates.set(
+      "lightModeTheme",
+      new Promise<void>((resolve) => {
+        releaseLightUpdate = resolve;
+      })
+    );
+    updateFailures.add("darkModeTheme");
+
+    const synchronization = expect(updateMermaidThemeSync(memento)).rejects.toThrow(
+      "Failed to update darkModeTheme"
+    );
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+    releaseLightUpdate();
+    await synchronization;
+
+    updateFailures.clear();
+    updateGates.clear();
+    markdownConfig["mermaid.syncTheme"] = false;
+    await updateMermaidThemeSync(memento);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
       darkModeTheme: "forest"
     });
   });


### PR DESCRIPTION
## What changed

- Wait for both Mermaid theme setting updates to settle.
- Record ownership for each setting that was actually updated before propagating an update error.
- Restore partially applied settings when synchronization is disabled.
- Add a user-facing changelog entry.

## Why

A partial update could change one of the user's global Mermaid settings without recording that change. The extension would then be unable to restore the original value.

## Validation

- Added a regression test where the light update succeeds after the dark update fails.
- Targeted Mermaid tests: 10/10 passed.
- Full unit suite: 242/242 passed.
- TypeScript, type-aware oxlint, oxfmt, build, and `git diff --check` passed.