### PR TITLE
fix: rewrite only project-root image src attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This file records notable changes that people can observe or act on when using t
 
 - Multi-paragraph footnotes now keep their indented paragraphs and formatting inside the footnote instead of rendering later blocks in the document body.
 
+- Raw HTML images now rewrite only project-root `src` paths, preserving `data-src` attributes and protocol-relative image URLs.
+
 ## [v4.4.1] - 2026-07-26
 
 v4.4.1 makes extension downloads and updates substantially smaller without changing Markdown preview behavior, settings, or supported VS Code versions.

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -1,11 +1,15 @@
 import type MarkdownIt from "markdown-it";
 
+const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
+const projectRootSrcAttributePattern =
+  /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(["'])(\/(?!\/)[^"']+)\2/i;
+
 function rewriteImgSrc(html: string): string {
-  return html.replace(
-    /<img\b([^>]*?)\bsrc=(["'])(\/[^"']+)\2([^>]*)>/gi,
-    (_match, before, quote, src, after) => {
-      return `<img${before}src=${quote}.${src}${quote}${after}>`;
-    }
+  return html.replace(imageTagPattern, (imageTag) =>
+    imageTag.replace(
+      projectRootSrcAttributePattern,
+      (_match, before, quote, src) => `${before}${quote}.${src}${quote}`
+    )
   );
 }
 

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -26,4 +26,16 @@ describe("markdown-it-github-image-url", () => {
     const html = md.render('<img src="/assets/logo.svg" alt="logo">');
     expect(html).toContain(`src="./assets/logo.svg"`);
   });
+
+  it("rewrites only the src attribute on raw HTML images", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render('<img data-src="/lazy.png" src="/actual.png">');
+    expect(html).toContain('data-src="/lazy.png" src="./actual.png"');
+  });
+
+  it("preserves protocol-relative image URLs", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render('<img src="//cdn.example.com/a.png">');
+    expect(html).toContain('src="//cdn.example.com/a.png"');
+  });
 });


### PR DESCRIPTION
## What changed

- Locate complete raw HTML `<img>` tags before rewriting URLs.
- Match only a whitespace-delimited `src` attribute inside each image tag.
- Preserve `data-src`, `srcset`, and protocol-relative `//` URLs.
- Add a user-facing changelog entry.

## Why

The previous word-boundary regex could rewrite `data-src` instead of the real `src`, and changed protocol-relative image URLs into invalid relative paths.

## Validation

- Added regression tests for `data-src` plus `src` and for protocol-relative URLs.
- Targeted image URL tests: 6/6 passed.
- Full unit suite: 243/243 passed.
- TypeScript, type-aware oxlint, oxfmt, build, and `git diff --check` passed.