### PR TITLE
fix: rewrite unquoted project-root image src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This file records notable changes that people can observe or act on when using t
 
 - Multi-paragraph footnotes now keep their indented paragraphs and formatting inside the footnote instead of rendering later blocks in the document body.
 
-- Raw HTML images now rewrite only project-root `src` paths, preserving `data-src` attributes and protocol-relative image URLs.
+- Raw HTML images now rewrite quoted and unquoted project-root `src` paths, preserving `data-src` attributes and protocol-relative image URLs.
 
 ## [v4.4.1] - 2026-07-26
 

--- a/src/plugins/markdown-it-github-image-url.ts
+++ b/src/plugins/markdown-it-github-image-url.ts
@@ -2,13 +2,14 @@ import type MarkdownIt from "markdown-it";
 
 const imageTagPattern = /<img(?=[\t\n\f\r />])(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi;
 const projectRootSrcAttributePattern =
-  /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(["'])(\/(?!\/)[^"']+)\2/i;
+  /(<img(?:[^"'<>]|"[^"]*"|'[^']*')*?[\t\n\f\r ]+src[\t\n\f\r ]*=[\t\n\f\r ]*)(?:(["'])(\/(?!\/)[^"']+)\2|(\/(?!\/)[^\t\n\f\r "'`=<>]+))/i;
 
 function rewriteImgSrc(html: string): string {
   return html.replace(imageTagPattern, (imageTag) =>
     imageTag.replace(
       projectRootSrcAttributePattern,
-      (_match, before, quote, src) => `${before}${quote}.${src}${quote}`
+      (_match, before, quote = "", quotedSrc, unquotedSrc) =>
+        `${before}${quote}.${quotedSrc ?? unquotedSrc}${quote}`
     )
   );
 }

--- a/tests/plugins/image-url.test.ts
+++ b/tests/plugins/image-url.test.ts
@@ -33,9 +33,21 @@ describe("markdown-it-github-image-url", () => {
     expect(html).toContain('data-src="/lazy.png" src="./actual.png"');
   });
 
+  it("rewrites an unquoted project-root src attribute", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render("<img data-src=/lazy.png src=/actual.png alt=logo>");
+    expect(html).toContain("data-src=/lazy.png src=./actual.png alt=logo");
+  });
+
   it("preserves protocol-relative image URLs", () => {
     const md = new MarkdownIt({ html: true }).use(githubImageUrl);
     const html = md.render('<img src="//cdn.example.com/a.png">');
     expect(html).toContain('src="//cdn.example.com/a.png"');
+  });
+
+  it("preserves unquoted protocol-relative image URLs", () => {
+    const md = new MarkdownIt({ html: true }).use(githubImageUrl);
+    const html = md.render("<img src=//cdn.example.com/a.png>");
+    expect(html).toContain("src=//cdn.example.com/a.png");
   });
 });


### PR DESCRIPTION
## What changed

- Rewrite valid unquoted project-root `src` attributes on raw HTML `<img>` tags.
- Preserve unquoted protocol-relative URLs and similarly named attributes such as `data-src`.
- Clarify the existing user-facing changelog entry.

## Why

The image URL rule only matched quoted attribute values. Valid HTML such as `<img src=/assets/logo.png>` therefore kept the project-root path and could fail to resolve in the local preview.

## Impact

Quoted and unquoted project-root image paths now follow the same preview behavior without changing external, protocol-relative, relative, `data-src`, or `srcset` values.

## Validation

- `pnpm exec vitest run tests/plugins/image-url.test.ts` — 8 passed
- `pnpm test` — 247 passed
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint --type-aware src/plugins/markdown-it-github-image-url.ts tests/plugins/image-url.test.ts`
- `pnpm exec oxfmt --check src/plugins/markdown-it-github-image-url.ts tests/plugins/image-url.test.ts CHANGELOG.md`
- `git diff --check`