### PR TITLE
test: enforce coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: nubx oxlint --type-aware .
 
       - name: Test
-        run: nub run test
+        run: nub run test:coverage
 
       - name: Verify Markdown compatibility
         run: nub scripts/verify/index.ts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,7 @@ jobs:
         run: nubx oxlint --type-aware .
 
       - name: Test
-        run: nub run test
+        run: nub run test:coverage
 
       - name: Verify Markdown compatibility
         run: nub scripts/verify/index.ts

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,8 +7,14 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/generated/**"]
+      include: ["src/**/*.ts", "scripts/**/*.ts"],
+      exclude: ["src/generated/**"],
+      thresholds: {
+        statements: 65,
+        branches: 60,
+        functions: 70,
+        lines: 65
+      }
     }
   }
 });


### PR DESCRIPTION
## What changed

- Measure coverage across both extension runtime code and repository scripts.
- Add global minimums for statements, branches, functions, and lines.
- Run the coverage command in pull-request CI and the publish workflow instead of the ungated unit-test command.
- Preserve the Markdown compatibility verifier added to both workflows.

## Why

The existing coverage command was informational: it only measured `src/**`, had no thresholds, and was not run by CI. Coverage could regress substantially while every required check remained green.

## Impact

Coverage now includes previously invisible script modules and blocks pull requests or releases when the aggregate drops below the established floor. This is internal verification work, so the changelog is intentionally unchanged under the repository admission rules.

## Final integrated baseline and thresholds

Measured after #1210, #1212–#1218 were merged:

- Statements: 68.07% (threshold 65%)
- Branches: 66.31% (threshold 60%)
- Functions: 73.45% (threshold 70%)
- Lines: 68.94% (threshold 65%)

The margins prevent accidental regressions without claiming that untested orchestration entrypoints are already fully covered.

## Validation

- `nub run test:coverage` — 45 files, 259 tests passed; all configured thresholds passed
- `nub scripts/verify/index.ts` — passed
- `pnpm exec vitest run --coverage --coverage.thresholds.lines=100` — failed as expected during gate validation, proving the threshold is enforced
- `pnpm exec tsc --noEmit` — passed
- `nubx oxlint --type-aware vitest.config.ts` — passed
- `nubx oxfmt --check vitest.config.ts .github/workflows/ci.yml .github/workflows/publish.yml` — passed
- `git diff --check` — passed

Vitest 4.1 coverage syntax was checked against the official v4.1 documentation.