### PR TITLE
fix: serialize Mermaid theme synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This file records notable changes that people can observe or act on when using t
 
 ### Mermaid
 
+- Overlapping theme changes now apply in request order, so the latest GitHub Markdown theme wins and turning off synchronization still restores your previous Mermaid themes.
+
 - Mermaid theme synchronization now restores any setting it changed when a partial update fails, preserving your previous light and dark theme choices.
 
 ### Markdown preview

--- a/src/integrations/mermaid.ts
+++ b/src/integrations/mermaid.ts
@@ -39,16 +39,21 @@ const mermaidExtensionIds = [
 ] as const;
 const MERMAID_LIGHT_THEME: MermaidTheme = "default";
 const MERMAID_DARK_THEME: MermaidTheme = "dark";
+let mermaidThemeOperationQueue: Promise<void> = Promise.resolve();
 
 export function getMermaidSyncTheme(): boolean {
   return getConfiguration().get<boolean>(section.syncTheme, true);
 }
 
-export async function updateMermaidThemeSync(memento: vscode.Memento): Promise<void> {
+export function updateMermaidThemeSync(memento: vscode.Memento): Promise<void> {
+  return enqueueMermaidThemeOperation(() => updateMermaidThemeSyncNow(memento));
+}
+
+async function updateMermaidThemeSyncNow(memento: vscode.Memento): Promise<void> {
   const configuration = getOriginMermaidThemeConfiguration();
 
   if (!getMermaidSyncTheme()) {
-    await restoreMermaidThemeSync(memento, configuration);
+    await restoreMermaidThemeSyncNow(memento, configuration);
     return;
   }
 
@@ -80,9 +85,16 @@ export async function updateMermaidThemeSync(memento: vscode.Memento): Promise<v
   }
 }
 
-export async function restoreMermaidThemeSync(
+export function restoreMermaidThemeSync(
   memento: vscode.Memento,
   configuration = getOriginMermaidThemeConfiguration()
+): Promise<void> {
+  return enqueueMermaidThemeOperation(() => restoreMermaidThemeSyncNow(memento, configuration));
+}
+
+async function restoreMermaidThemeSyncNow(
+  memento: vscode.Memento,
+  configuration: vscode.WorkspaceConfiguration
 ): Promise<void> {
   const snapshot = memento.get<MermaidThemeSnapshot>(snapshotKey);
   if (!snapshot || !hasMermaidThemeConfiguration(configuration)) {
@@ -105,6 +117,12 @@ export async function restoreMermaidThemeSync(
 
   await Promise.all(updates);
   await memento.update(snapshotKey, undefined);
+}
+
+function enqueueMermaidThemeOperation(operation: () => Promise<void>): Promise<void> {
+  const queuedOperation = mermaidThemeOperationQueue.then(operation);
+  mermaidThemeOperationQueue = queuedOperation.catch(() => {});
+  return queuedOperation;
 }
 
 function resolveMermaidThemes(): readonly [MermaidTheme, MermaidTheme] {

--- a/tests/integrations/mermaid.test.ts
+++ b/tests/integrations/mermaid.test.ts
@@ -56,7 +56,7 @@ vi.mock("vscode", () => ({
   }
 }));
 
-import { updateMermaidThemeSync } from "../../src/integrations/mermaid";
+import { restoreMermaidThemeSync, updateMermaidThemeSync } from "../../src/integrations/mermaid";
 
 describe("Mermaid theme synchronization", () => {
   beforeEach(() => {
@@ -116,6 +116,33 @@ describe("Mermaid theme synchronization", () => {
     ]);
   });
 
+  it("keeps the latest theme request when overlapping updates would finish out of order", async () => {
+    const memento = createTestMemento();
+    let releaseFirstUpdate = () => {};
+    const firstUpdateGate = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    updateGates.set("lightModeTheme", firstUpdateGate);
+    updateGates.set("darkModeTheme", firstUpdateGate);
+
+    const firstUpdate = updateMermaidThemeSync(memento);
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+
+    markdownConfig["theme.mode"] = "vscode";
+    updateGates.clear();
+    const latestUpdate = updateMermaidThemeSync(memento);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    releaseFirstUpdate();
+    await Promise.all([firstUpdate, latestUpdate]);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "vscode",
+      darkModeTheme: "vscode"
+    });
+  });
+
   it("also supports the legacy external Mermaid extension", async () => {
     const memento = createTestMemento();
     mermaidExtensionIds = new Set(["bierner.markdown-mermaid"]);
@@ -141,6 +168,57 @@ describe("Mermaid theme synchronization", () => {
       { key: "lightModeTheme", value: "neutral", target: 1 },
       { key: "darkModeTheme", value: "forest", target: 1 }
     ]);
+  });
+
+  it("restores the original themes when disabling synchronization overlaps an update", async () => {
+    const memento = createTestMemento();
+    let releaseUpdate = () => {};
+    const updateGate = new Promise<void>((resolve) => {
+      releaseUpdate = resolve;
+    });
+    updateGates.set("lightModeTheme", updateGate);
+    updateGates.set("darkModeTheme", updateGate);
+
+    const update = updateMermaidThemeSync(memento);
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+
+    markdownConfig["mermaid.syncTheme"] = false;
+    const restore = updateMermaidThemeSync(memento);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    releaseUpdate();
+    await Promise.all([update, restore]);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
+  });
+
+  it("restores the original themes when deactivation overlaps an update", async () => {
+    const memento = createTestMemento();
+    let releaseUpdate = () => {};
+    const updateGate = new Promise<void>((resolve) => {
+      releaseUpdate = resolve;
+    });
+    updateGates.set("lightModeTheme", updateGate);
+    updateGates.set("darkModeTheme", updateGate);
+
+    const update = updateMermaidThemeSync(memento);
+    await vi.waitFor(() => expect(updateCalls).toHaveLength(2));
+
+    const restore = restoreMermaidThemeSync(memento);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    releaseUpdate();
+    await Promise.all([update, restore]);
+
+    expect(mermaidGlobalConfig).toEqual({
+      lightModeTheme: "neutral",
+      darkModeTheme: "forest"
+    });
   });
 
   it("does not overwrite Mermaid choices made while synchronization was active", async () => {


### PR DESCRIPTION
## Summary

- serialize Mermaid theme updates and restores through one shared operation queue
- keep the latest requested GitHub Markdown theme authoritative when configuration events overlap
- restore the original Mermaid settings when disabling synchronization or deactivating overlaps an in-flight update
- document the user-visible reliability fix under `Unreleased`

## Root cause

Theme updates, disabling synchronization, and deactivation could call the companion extension's settings API concurrently. A slower earlier write could finish after a newer request and overwrite it. Restore could also read the snapshot before the in-flight update recorded which values it owned, then clear or miss the restoration state.

## Invariants

- Mermaid writes and restores commit in invocation order, so the latest request wins.
- The original global light and dark themes are captured once for a synchronization ownership period.
- Restore only changes slots that still equal the last value applied by this extension, preserving user edits made while synchronization is active.
- A failed operation rejects its own caller but does not poison the queue for later update or restore requests.

## Checks

- `pnpm vitest run tests/integrations/mermaid.test.ts` — 13 passed
- `nub run test` — 45 files, 248 tests passed
- `tsc` — passed
- `nubx oxlint --type-aware .` — passed
- `nubx oxfmt --check src/integrations/mermaid.ts tests/integrations/mermaid.test.ts CHANGELOG.md` — passed
- `nub run build` — passed