### PR TITLE
fix: avoid nested theme containers in footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This file records notable changes that people can observe or act on when using t
 
 ### Markdown preview
 
+- Footnotes now render inside a single theme container, preventing nested preview styles from altering their layout and appearance.
+
 - Multi-paragraph footnotes now keep their indented paragraphs and formatting inside the footnote instead of rendering later blocks in the document body.
 
 - Raw HTML images now rewrite only project-root `src` paths, preserving `data-src` attributes and protocol-relative image URLs.

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -12,12 +12,17 @@ type FootnoteState = MarkdownState & {
   src: string;
 };
 
+type FragmentRenderer = (tokens: MarkdownToken[]) => string;
+
 const footnoteDefinitionLinePattern = /^\[\^([^\]\n]+)\]:[ \t]*(.*)$/;
 const footnoteReferencePattern = /\[\^([^\]\n]+)\]/g;
 const footnoteOrderKey = "githubMarkdownFootnoteOrder";
 const footnoteReferencesKey = "githubMarkdownFootnoteReferences";
 
 export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
+  const render = md.renderer.render.bind(md.renderer);
+  const renderFragment: FragmentRenderer = (tokens) => render(tokens, md.options, {});
+
   md.core.ruler.after("inline", "github-markdown-footnotes", (state) => {
     const markdownState = state as unknown as FootnoteState;
     const footnotes = collectFootnotes(markdownState.tokens, markdownState.src);
@@ -26,7 +31,7 @@ export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
     applyFootnoteReferences(markdownState, footnotes.definitions);
 
     if (footnotes.definitions.size > 0) {
-      appendFootnoteSection(markdownState, footnotes.definitions, md);
+      appendFootnoteSection(markdownState, footnotes.definitions, md, renderFragment);
     }
   });
 
@@ -238,7 +243,8 @@ function applyFootnoteReferences(state: MarkdownState, definitions: Map<string, 
 function appendFootnoteSection(
   state: MarkdownState,
   definitions: Map<string, string>,
-  md: MarkdownIt
+  md: MarkdownIt,
+  renderFragment: FragmentRenderer
 ) {
   const footnoteOrder = state.env[footnoteOrderKey];
   const referencedLabels = Array.isArray(footnoteOrder)
@@ -261,7 +267,7 @@ function appendFootnoteSection(
         .filter((reference) => reference.label === label)
         .map((reference) => renderBackref(reference.number, reference.referenceCount))
         .join(" ");
-      const content = renderFootnoteDefinition(definition, backrefs, state, md);
+      const content = renderFootnoteDefinition(definition, backrefs, state, md, renderFragment);
       return `<li id="user-content-fn-${number}">
 ${content}
 </li>`;
@@ -294,7 +300,8 @@ function renderFootnoteDefinition(
   definition: string,
   backrefs: string,
   state: MarkdownState,
-  md: MarkdownIt
+  md: MarkdownIt,
+  renderFragment: FragmentRenderer
 ): string {
   const tokens = md.parse(definition, {});
   let lastInline: MarkdownToken | undefined;
@@ -316,7 +323,7 @@ function renderFootnoteDefinition(
     lastInline.children.push(separator, backref);
   }
 
-  const content = md.renderer.render(tokens, md.options, {}).trimEnd();
+  const content = renderFragment(tokens).trimEnd();
   return lastInline ? content : `${content}\n<p dir="auto">${backrefs}</p>`;
 }
 

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -70,6 +70,17 @@ describe("plugin chain integration", () => {
     expect(html).toContain("footnote-ref");
   });
 
+  it("renders footnote fragments without nesting the document theme container", () => {
+    const md = createChain();
+    const html = md.render(
+      'Ref[^1].\n\n[^1]: :rocket: مرحبا <img src="/assets/logo.png" alt="logo">'
+    );
+
+    expect(html.match(/class="vscode-github-markdown"/g)).toHaveLength(1);
+    expect(html).toContain('<p dir="auto">🚀 مرحبا');
+    expect(html).toContain('src="./assets/logo.png"');
+  });
+
   it("renders emoji inside an alert", () => {
     const md = createChain();
     const html = md.render("> [!TIP]\n> Use :rocket: for speed.");


### PR DESCRIPTION
## Summary

- render footnote definition fragments without re-entering the document-level theme wrapper
- keep the existing emoji, directionality, and project-root image rewriting behavior inside footnotes
- add a full production plugin-chain regression test and a user-facing changelog entry

## Root cause

Footnote definitions are parsed into a secondary token fragment. That fragment was rendered through the current `md.renderer.render` function after the theme plugin had decorated it as a whole-document renderer, so every footnote inserted another `.vscode-github-markdown` root container inside the outer preview container.

## Impact

Footnotes now remain inside the preview's single theme root, avoiding nested theme styles and matching the intended GitHub-style document structure. Fragment rendering still uses the shared parser and renderer rules, so emoji conversion, automatic direction, and HTML image path rewriting continue to apply.

## Checks

- `pnpm exec vitest run tests/plugins/integration.test.ts` (9 passed)
- `nub run test` (246 passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint --type-aware .`
- `pnpm exec oxfmt --check src/plugins/markdown-it-github-footnotes.ts tests/plugins/integration.test.ts CHANGELOG.md`
- `nub scripts/verify/index.ts`
- `pnpm run verify:parity` (footnotes light/dark: 0 px difference)