### PR TITLE
fix: resolve cross-references inside footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This file records notable changes that people can observe or act on when using t
 
 - Footnotes now render inside a single theme container, preventing nested preview styles from altering their layout and appearance.
 
+- Footnotes referenced from another footnote now resolve with GitHub-matching numbering and return links instead of appearing as literal Markdown.
+
 - Multi-paragraph footnotes now keep their indented paragraphs and formatting inside the footnote instead of rendering later blocks in the document body.
 
 - Raw HTML images now rewrite only project-root `src` paths, preserving `data-src` attributes and protocol-relative image URLs.

--- a/src/plugins/markdown-it-github-footnotes.ts
+++ b/src/plugins/markdown-it-github-footnotes.ts
@@ -8,6 +8,14 @@ type FootnoteReference = {
   referenceCount: number;
 };
 
+type FootnoteGraph = {
+  definitions: Map<string, string>;
+  order: string[];
+  numbers: Map<string, number>;
+  referenceCounts: Map<string, number>;
+  references: FootnoteReference[];
+};
+
 type FootnoteState = MarkdownState & {
   src: string;
 };
@@ -28,10 +36,10 @@ export default function markdownItGitHubFootnotes(md: MarkdownIt): MarkdownIt {
     const footnotes = collectFootnotes(markdownState.tokens, markdownState.src);
     markdownState.tokens = footnotes.tokens;
 
-    applyFootnoteReferences(markdownState, footnotes.definitions);
+    const definitionTokens = applyFootnoteReferences(markdownState, footnotes.definitions, md);
 
     if (footnotes.definitions.size > 0) {
-      appendFootnoteSection(markdownState, footnotes.definitions, md, renderFragment);
+      appendFootnoteSection(markdownState, definitionTokens, renderFragment);
     }
   });
 
@@ -163,16 +171,49 @@ function parseFootnoteDefinitions(content: string): Map<string, string> | undefi
   return definitions.size > 0 ? definitions : undefined;
 }
 
-function applyFootnoteReferences(state: MarkdownState, definitions: Map<string, string>) {
+function applyFootnoteReferences(
+  state: MarkdownState,
+  definitions: Map<string, string>,
+  md: MarkdownIt
+): Map<string, MarkdownToken[]> {
+  const definitionTokens = new Map<string, MarkdownToken[]>();
   if (definitions.size === 0) {
-    return;
+    return definitionTokens;
   }
 
-  const numbers = new Map<string, number>();
-  const referenceCounts = new Map<string, number>();
-  const references: FootnoteReference[] = [];
+  const graph: FootnoteGraph = {
+    definitions,
+    order: [],
+    numbers: new Map<string, number>(),
+    referenceCounts: new Map<string, number>(),
+    references: []
+  };
 
-  for (const token of state.tokens) {
+  applyFootnoteReferencesToTokens(state.tokens, state, graph);
+
+  for (let index = 0; index < graph.order.length; index += 1) {
+    const label = graph.order[index];
+    const definition = label ? definitions.get(label) : undefined;
+    if (!label || !definition) {
+      continue;
+    }
+
+    const tokens = md.parse(definition, {});
+    applyFootnoteReferencesToTokens(tokens, state, graph);
+    definitionTokens.set(label, tokens);
+  }
+
+  state.env[footnoteOrderKey] = graph.order;
+  state.env[footnoteReferencesKey] = graph.references;
+  return definitionTokens;
+}
+
+function applyFootnoteReferencesToTokens(
+  tokens: MarkdownToken[],
+  state: MarkdownState,
+  graph: FootnoteGraph
+): void {
+  for (const token of tokens) {
     if (token.type !== "inline" || !token.children) {
       continue;
     }
@@ -192,7 +233,7 @@ function applyFootnoteReferences(state: MarkdownState, definitions: Map<string, 
         const label = match[1]?.trim();
         const matchIndex = match.index ?? -1;
 
-        if (!label || !definitions.has(label) || matchIndex < 0) {
+        if (!label || !graph.definitions.has(label) || matchIndex < 0) {
           continue;
         }
 
@@ -202,11 +243,15 @@ function applyFootnoteReferences(state: MarkdownState, definitions: Map<string, 
           nextChildren.push(textToken);
         }
 
-        const number = numbers.get(label) ?? numbers.size + 1;
-        numbers.set(label, number);
-        const referenceCount = (referenceCounts.get(label) ?? 0) + 1;
-        referenceCounts.set(label, referenceCount);
-        references.push({ label, number, referenceCount });
+        let number = graph.numbers.get(label);
+        if (number === undefined) {
+          number = graph.order.length + 1;
+          graph.numbers.set(label, number);
+          graph.order.push(label);
+        }
+        const referenceCount = (graph.referenceCounts.get(label) ?? 0) + 1;
+        graph.referenceCounts.set(label, referenceCount);
+        graph.references.push({ label, number, referenceCount });
 
         const htmlToken = new state.Token("html_inline", "", 0);
         htmlToken.content = `<sup class="footnote-ref"><a href="#user-content-fn-${number}" id="${footnoteReferenceId(
@@ -233,17 +278,11 @@ function applyFootnoteReferences(state: MarkdownState, definitions: Map<string, 
 
     token.children = nextChildren;
   }
-
-  state.env[footnoteOrderKey] = [...numbers.entries()]
-    .sort((left, right) => left[1] - right[1])
-    .map(([label]) => label);
-  state.env[footnoteReferencesKey] = references;
 }
 
 function appendFootnoteSection(
   state: MarkdownState,
-  definitions: Map<string, string>,
-  md: MarkdownIt,
+  definitionTokens: Map<string, MarkdownToken[]>,
   renderFragment: FragmentRenderer
 ) {
   const footnoteOrder = state.env[footnoteOrderKey];
@@ -257,8 +296,8 @@ function appendFootnoteSection(
 
   const items = referencedLabels
     .map((label, index) => {
-      const definition = definitions.get(label);
-      if (!definition) {
+      const tokens = definitionTokens.get(label);
+      if (!tokens) {
         return "";
       }
 
@@ -267,7 +306,7 @@ function appendFootnoteSection(
         .filter((reference) => reference.label === label)
         .map((reference) => renderBackref(reference.number, reference.referenceCount))
         .join(" ");
-      const content = renderFootnoteDefinition(definition, backrefs, state, md, renderFragment);
+      const content = renderFootnoteDefinition(tokens, backrefs, state, renderFragment);
       return `<li id="user-content-fn-${number}">
 ${content}
 </li>`;
@@ -297,13 +336,11 @@ function normalizeFootnoteDefinition(definition: string): string {
 }
 
 function renderFootnoteDefinition(
-  definition: string,
+  tokens: MarkdownToken[],
   backrefs: string,
   state: MarkdownState,
-  md: MarkdownIt,
   renderFragment: FragmentRenderer
 ): string {
-  const tokens = md.parse(definition, {});
   let lastInline: MarkdownToken | undefined;
 
   for (const token of tokens) {

--- a/tests/plugins/footnotes.test.ts
+++ b/tests/plugins/footnotes.test.ts
@@ -39,6 +39,29 @@ describe("markdown-it-github-footnotes", () => {
     expect(html).toContain('href="#user-content-fn-2"');
   });
 
+  it("resolves a footnote referenced from another footnote definition", () => {
+    const md = new MarkdownIt().use(githubFootnotes);
+    const html = md.render("Body[^a].\n\n[^a]: See note[^b].\n\n[^b]: Nested note.");
+    const footnoteA = html.match(/<li id="user-content-fn-1">[\s\S]*?<\/li>/)?.[0];
+    const footnoteB = html.match(/<li id="user-content-fn-2">[\s\S]*?<\/li>/)?.[0];
+
+    expect(html).toContain(
+      '<a href="#user-content-fn-1" id="user-content-fnref-1" data-footnote-ref="" aria-describedby="footnote-label">1</a>'
+    );
+    expect(footnoteA).toContain(
+      '<a href="#user-content-fn-2" id="user-content-fnref-2" data-footnote-ref="" aria-describedby="footnote-label">2</a>'
+    );
+    expect(footnoteA).toContain("See note");
+    expect(footnoteA).toContain(
+      'href="#user-content-fnref-1" data-footnote-backref="" aria-label="Back to reference 1"'
+    );
+    expect(footnoteB).toContain("Nested note.");
+    expect(footnoteB).toContain(
+      'href="#user-content-fnref-2" data-footnote-backref="" aria-label="Back to reference 2"'
+    );
+    expect(html).not.toContain("[^b]");
+  });
+
   it("parses consecutive footnote definitions as separate notes", () => {
     const md = new MarkdownIt().use(githubFootnotes);
     const html = md.render(


### PR DESCRIPTION
## Root cause

Footnote definitions were parsed and rendered independently after the document reference pass, using an empty parsing environment. References found inside a definition therefore never joined the document's numbering and reference graph.

## Impact

A footnote such as `[^a]: See note[^b].` left `[^b]` as literal Markdown and omitted the referenced definition from the preview. The extension now follows reachable references through footnote definitions, assigns numbers in encounter order, and renders the corresponding return links.

## Checks

- `pnpm exec vitest run tests/plugins/footnotes.test.ts` — 10 passed
- `pnpm test` — 246 passed
- `pnpm exec tsc --noEmit` — passed
- `nubx oxlint --type-aware .` — 0 warnings, 0 errors
- `pnpm run verify:parity` — passed, including 0 px differences for light/dark footnotes
- GitHub `/markdown` comparison — confirmed A=1, nested B=2, and matching back-reference behavior
- `nub scripts/verify/index.ts` — still blocked by the existing `wrapped footnotes` assertion for the nested theme-root issue; that separate defect is intentionally outside this PR
