### PR TITLE
ci: run Markdown compatibility verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Test
         run: nub run test
 
+      - name: Verify Markdown compatibility
+        run: nub scripts/verify/index.ts
+
       - name: Verify Markdown parity baseline
         run: pnpm run verify:parity
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Test
         run: nub run test
 
+      - name: Verify Markdown compatibility
+        run: nub scripts/verify/index.ts
+
       - name: Verify Markdown parity baseline
         run: pnpm run verify:parity
 


### PR DESCRIPTION
## What changed

- Run `nub scripts/verify/index.ts` in pull-request CI.
- Run the same compatibility verifier before publishing a release.

## Why

The repository's dedicated Markdown compatibility verifier covered contracts that the Vitest and parity commands did not execute. It detected the nested footnote theme-wrapper regression while the previous required CI remained green.

## Impact

Pull requests and releases now stop when task-list, footnote, alert, emoji, strikethrough, tagfilter, directionality, or documented dependency-boundary verification fails. This is internal verification work, so the changelog is intentionally unchanged.

## Validation

Rebased onto `main` after #1213 and #1214 merged:

- `nub scripts/verify/index.ts` — passed
- `pnpm test` — passed
- `pnpm exec oxfmt --check .github/workflows/ci.yml .github/workflows/publish.yml` — passed
- `git diff --check` — passed