### PR TITLE
refactor: share Markdown-It plugin composition

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,15 +3,7 @@ import type MarkdownIt from "markdown-it";
 import { registerThemeCommands } from "./commands";
 import { registerMarkdownPreviewEvents } from "./events";
 import { restoreMermaidThemeSync, updateMermaidThemeSync } from "./integrations/mermaid";
-import alerts from "./plugins/markdown-it-github-alerts";
-import directionality from "./plugins/markdown-it-github-directionality";
-import emoji from "./plugins/markdown-it-github-emoji";
-import footnotes from "./plugins/markdown-it-github-footnotes";
-import imageUrl from "./plugins/markdown-it-github-image-url";
-import strikethrough from "./plugins/markdown-it-github-strikethrough";
-import tagfilter from "./plugins/markdown-it-github-tagfilter";
-import taskLists from "./plugins/markdown-it-github-task-lists";
-import theme from "./plugins/markdown-it-github-theme";
+import { extendMarkdownIt } from "./markdown-it";
 
 let activeMemento: vscode.Memento | undefined;
 
@@ -28,20 +20,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<{
     console.error("[github-markdown] Failed to sync Mermaid theme on activation:", error);
   }
 
-  return {
-    extendMarkdownIt(md: MarkdownIt): MarkdownIt {
-      return md
-        .use(strikethrough)
-        .use(tagfilter)
-        .use(taskLists)
-        .use(alerts)
-        .use(emoji)
-        .use(footnotes)
-        .use(directionality)
-        .use(theme)
-        .use(imageUrl);
-    }
-  };
+  return { extendMarkdownIt };
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/markdown-it.ts
+++ b/src/markdown-it.ts
@@ -1,0 +1,23 @@
+import type MarkdownIt from "markdown-it";
+import alerts from "./plugins/markdown-it-github-alerts";
+import directionality from "./plugins/markdown-it-github-directionality";
+import emoji from "./plugins/markdown-it-github-emoji";
+import footnotes from "./plugins/markdown-it-github-footnotes";
+import imageUrl from "./plugins/markdown-it-github-image-url";
+import strikethrough from "./plugins/markdown-it-github-strikethrough";
+import tagfilter from "./plugins/markdown-it-github-tagfilter";
+import taskLists from "./plugins/markdown-it-github-task-lists";
+import theme from "./plugins/markdown-it-github-theme";
+
+export function extendMarkdownIt(md: MarkdownIt): MarkdownIt {
+  return md
+    .use(strikethrough)
+    .use(tagfilter)
+    .use(taskLists)
+    .use(alerts)
+    .use(emoji)
+    .use(footnotes)
+    .use(directionality)
+    .use(theme)
+    .use(imageUrl);
+}

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -89,6 +89,7 @@ vi.mock("vscode", () => ({
 }));
 
 import { activate, deactivate } from "../src/extension";
+import { extendMarkdownIt } from "../src/markdown-it";
 
 function createContext(): vscode.ExtensionContext {
   return {
@@ -128,7 +129,7 @@ describe("extension lifecycle", () => {
     vi.restoreAllMocks();
   });
 
-  it("registers and owns commands and configuration events during activation", async () => {
+  it("registers and owns commands, configuration events, and Markdown-It composition", async () => {
     const context = createContext();
 
     const api = await activate(context);
@@ -142,6 +143,7 @@ describe("extension lifecycle", () => {
     expect(harness.configurationListener).toBeTypeOf("function");
     expect(context.subscriptions).toHaveLength(5);
     expect(harness.mermaidUpdates).toHaveLength(2);
+    expect(api).toEqual(expect.objectContaining({ extendMarkdownIt }));
 
     const html = api.extendMarkdownIt(new MarkdownIt({ html: true })).render("# Hello");
     expect(html).toContain('class="vscode-github-markdown"');

--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -27,27 +27,10 @@ vi.mock("vscode", () => ({
   }
 }));
 
-import alerts from "../../src/plugins/markdown-it-github-alerts";
-import directionality from "../../src/plugins/markdown-it-github-directionality";
-import emoji from "../../src/plugins/markdown-it-github-emoji";
-import footnotes from "../../src/plugins/markdown-it-github-footnotes";
-import imageUrl from "../../src/plugins/markdown-it-github-image-url";
-import strikethrough from "../../src/plugins/markdown-it-github-strikethrough";
-import tagfilter from "../../src/plugins/markdown-it-github-tagfilter";
-import taskLists from "../../src/plugins/markdown-it-github-task-lists";
-import theme from "../../src/plugins/markdown-it-github-theme";
+import { extendMarkdownIt } from "../../src/markdown-it";
 
 function createChain(): MarkdownIt {
-  return new MarkdownIt({ html: true })
-    .use(strikethrough)
-    .use(tagfilter)
-    .use(taskLists)
-    .use(alerts)
-    .use(emoji)
-    .use(footnotes)
-    .use(directionality)
-    .use(theme)
-    .use(imageUrl);
+  return extendMarkdownIt(new MarkdownIt({ html: true }));
 }
 
 describe("plugin chain integration", () => {


### PR DESCRIPTION
## Summary

- centralize the complete Markdown-It plugin sequence in one web-compatible `extendMarkdownIt` composition function
- return that function directly from extension activation
- make the fast plugin integration suite consume the same composition and assert the activation API exposes it

## Why

The fast integration test manually repeated the production plugin order. Production could therefore add, remove, or reorder a plugin while the integration suite continued exercising a stale chain. Keeping one composition boundary makes those tests follow the real production sequence without exposing individual plugin internals.

## Impact

No user-visible rendering behavior changes. The existing plugin order and extension API are preserved. No changelog entry is needed.

## Validation

- `pnpm exec vitest run tests/plugins/integration.test.ts tests/extension.test.ts` — 12 tests passed
- `pnpm run test` — 45 files, 245 tests passed
- `pnpm exec tsc --noEmit` — passed
- `nubx oxlint --type-aware .` — 0 warnings, 0 errors
- `nubx oxfmt --check ...` — passed for all touched files
- `pnpm run build` — passed
- `pnpm run verify:parity` — passed
- `nub scripts/verify/index.ts` — still reports the pre-existing `wrapped footnotes` assertion caused by the separately tracked nested footnote theme-container defect; this PR intentionally does not change rendering behavior