### PR TITLE
test: verify render idempotence on one instance

### DIFF
--- a/tests/plugins/integration.test.ts
+++ b/tests/plugins/integration.test.ts
@@ -83,12 +83,26 @@ describe("plugin chain integration", () => {
     expect(html).toContain("Second footnote.");
   });
 
-  it("idempotent: re-rendering same input produces same output", () => {
+  it("produces the same output when one instance renders the same input twice", () => {
     const input =
       "- [x] Task\n\n> [!WARNING]\n> :warning: Danger.\n\nFootnote[^1].\n\n[^1]: Details.";
-    const md1 = createChain();
-    const md2 = createChain();
-    expect(md1.render(input)).toBe(md2.render(input));
+    const md = createChain();
+    const firstRender = md.render(input);
+
+    expect(md.render(input)).toBe(firstRender);
+  });
+
+  it("does not leak render state across different inputs", () => {
+    const input =
+      "- [x] Task\n\n> [!WARNING]\n> :warning: Danger.\n\nFootnote[^1].\n\n[^1]: Details.";
+    const interveningInput =
+      "> [!TIP]\n> A different document.\n\nAnother footnote[^2].\n\n[^2]: Other details.";
+    const md = createChain();
+    const firstRender = md.render(input);
+
+    md.render(interveningInput);
+
+    expect(md.render(input)).toBe(firstRender);
   });
 
   it("wraps final output in theme container", () => {


### PR DESCRIPTION
## Summary

- reuse one long-lived `MarkdownIt` plugin-chain instance for repeated A → A renders
- add an A → B → A case that detects state leaking between different documents
- compare rendered HTML so the tests express the observable integration contract

## Why

The previous idempotence test compared two newly created instances. It could pass even if a plugin retained mutable environment, token, or renderer state across renders on the same instance.

## Impact

Test coverage only. Runtime behavior and user-facing output are unchanged, so no changelog entry is needed.

## Validation

- `pnpm exec vitest run tests/plugins/integration.test.ts` — 9 tests passed
- `nub run test` — 246 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint --type-aware .`
- `pnpm exec oxfmt --check tests/plugins/integration.test.ts`
- `git diff --check`