### PR TITLE
docs: add Serena project memories

### DIFF
--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,10 @@
+# Conventions
+
+- Keep changes minimal and directly tied to GitHub Markdown parity.
+- Use built-in markdown.markdownItPlugins, markdown.previewScripts, and markdown.previewStyles hooks when sufficient.
+- Do not import Node-only APIs into src runtime unless web-extension support is intentionally changed; Node APIs are acceptable in scripts/.
+- README.md is English default; keep README.zh-CN.md aligned for shared content.
+- CHANGELOG entries must satisfy docs/CHANGELOG_STYLE_GUIDE.md admission rules and describe only user-observable/actionable outcomes.
+- Do not raise engines.vscode unless implementation requires newer APIs.
+- Tests should exercise observable rendered HTML or extension lifecycle through the module interface; full-chain tests are needed for renderer-rule ordering interactions.
+- GitHub Issues are the issue/PRD source; follow docs/agents/issue-tracker.md.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,8 @@
+# Core
+
+- VS Code web-compatible Markdown preview extension; runtime uses built-in markdown extension hooks, not a custom preview.
+- Runtime entry: src/extension.ts registers theme commands, configuration events, Mermaid theme integration, and one ordered markdown-it plugin chain.
+- Plugin order is an observable invariant: strikethrough, tagfilter, task lists, alerts, emoji, footnotes, directionality, theme wrapper, image URL rewrite.
+- Runtime must remain browser-compatible because package.json declares both main and browser as dist/extension.js.
+- Script/tooling domains live under scripts/: build, drift, emoji, host, package-audit, parity, release, shared, verify.
+- Read `mem:tech_stack` for pinned toolchain, `mem:conventions` for repository-specific design rules, and `mem:task_completion` before finishing changes.

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone,
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets.
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes.
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,10 @@
+# Suggested Commands
+
+- Toolchain: `mise install`; dependencies: `pnpm install`.
+- Build/watch: `nub run build`, `nub run dev`.
+- Unit tests: `nub run test`; watch: `nub run test:watch`; coverage: `nub run test:coverage`.
+- Host checks: `nub run test:host:desktop`, `nub run test:host:web`; preview variants use the corresponding `:preview` commands.
+- Parity: `nub run verify:parity`; remote probe/report commands are in package.json.
+- Lint: `nubx oxlint .`; type-aware lint: `nubx oxlint --type-aware .`; format: `nubx oxfmt .`.
+- Package: `nub run package`.
+- Repository AGENTS.md requires every shell command to be prefixed with `rtk`; prefix each segment of a chain.

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,10 @@
+# Task Completion
+
+- Run the narrowest relevant Vitest file(s), then `nub run test` when runtime or shared scripts changed.
+- Run `nubx oxlint .` and `nubx oxlint --type-aware .` for TypeScript changes.
+- Run `nubx oxfmt .` or its check equivalent as appropriate; do not overwrite unrelated user formatting.
+- Run `nub run build` for runtime/build configuration changes.
+- Run `nub run verify:parity` for Markdown rendering/parity changes.
+- Run relevant desktop and web host checks when extension-host behavior or compatibility changes.
+- Evaluate CHANGELOG admission for every change; update [Unreleased] only for eligible user-visible outcomes.
+- Recheck git status/diff before finishing and preserve unrelated worktree changes.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,7 @@
+# Tech Stack
+
+- TypeScript with strict, isolatedModules, noUncheckedIndexedAccess, exactOptionalPropertyTypes, noImplicitOverride, noPropertyAccessFromIndexSignature; ES2023 + Bundler resolution.
+- VS Code extension API minimum comes from engines.vscode; @types/vscode matches that minimum and is not the development-host version.
+- pnpm + mise manage the toolchain; Nub runs TypeScript scripts directly.
+- markdown-it supplies parsing/rendering; Vitest + V8 coverage; oxlint/tsgolint + oxfmt; lefthook pre-commit.
+- tsdown bundles the extension and host smoke tests; Playwright/pixelmatch support parity and preview validation.


### PR DESCRIPTION
## What changed

- Add a Serena memory graph rooted at `mem:core`.
- Record durable repository conventions, toolchain facts, common commands, and completion checks.
- Document memory maintenance and discovery rules so future agents load only relevant project context.

## Why

The repository already tracks `.serena/project.yml`, but had no shared project memories. Every new session therefore had to rediscover stable constraints such as web-extension compatibility, Markdown-It plugin ordering, changelog admission, and the expected verification commands.

## Impact

This is agent-facing documentation only. It does not change extension runtime behavior, packaging, or user-facing output, so no changelog entry is needed.

## Validation

- `nubx oxfmt --check .serena/memories/*.md` — passed
- Sensitive-value scan for absolute user paths, tokens, secrets, and passwords — no matches
- `git diff --cached --check` — passed